### PR TITLE
Fix light bugs

### DIFF
--- a/lib/TuyaOAuth2Client.js
+++ b/lib/TuyaOAuth2Client.js
@@ -190,6 +190,17 @@ class TuyaOAuth2Client extends OAuth2Client {
     });
   }
 
+  async getSpecification({
+    deviceId,
+  }) {
+    const token = await this.getToken();
+    const apiUrl = TuyaOAuth2Constants.API_URL[token.region];
+
+    return this.get({
+      path: `${apiUrl}/v1.0/iot-03/devices/${deviceId}/specification`,
+    });
+  }
+
   // Documentation: https://developer.tuya.com/en/docs/cloud/d65d46643b?id=Kb3ob6g63p4xh
   async getDeviceStatus({
     deviceId,

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -96,7 +96,9 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     // light_mode
     if (status['work_mode']) {
       if (status['work_mode'] === 'colour') {
-        this.setCapabilityValue('light_mode', 'color').catch(this.error);
+        if (this.hasCapability('light_mode')) {
+          this.setCapabilityValue('light_mode', 'color').catch(this.error);
+        }
 
         // dim
         if (status['colour_data']) {
@@ -111,7 +113,9 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
       }
 
       if (status['work_mode'] === 'white') {
-        this.setCapabilityValue('light_mode', 'temperature').catch(this.error);
+        if (this.hasCapability('light_mode')) {
+          this.setCapabilityValue('light_mode', 'temperature').catch(this.error);
+        }
 
         // dim
         if (typeof status['bright_value'] === 'number') {

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -158,7 +158,16 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
   }) {
     const commands = [];
 
-    if (this.hasCapability('light_mode') && light_mode === 'color') {
+    // Light mode is not available when a light only has temperature or color
+    if (!this.hasCapability('light_mode')) {
+      if (this.hasCapability('light_hue')) {
+        light_mode = 'color';
+      } else if (this.hasCapability('light_temperature')) {
+        light_mode = 'temperature';
+      }
+    }
+
+    if (light_mode === 'color') {
       if (this.hasTuyaCapability('colour_data')) {
         commands.push({
           code: 'colour_data',
@@ -180,7 +189,7 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
           },
         });
       }
-    } else if (this.hasCapability('light_mode') && light_mode === 'temperature') {
+    } else if (light_mode === 'temperature') {
       if (this.hasTuyaCapability('bright_value')) {
         commands.push({
           code: 'bright_value',

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -3,34 +3,6 @@
 'use strict';
 
 const TuyaOAuth2Device = require('./TuyaOAuth2Device');
-const TuyaOAuth2Constants = require('./TuyaOAuth2Constants');
-
-const {
-  LIGHT_COLOUR_DATA_V1_HUE_MIN,
-  LIGHT_COLOUR_DATA_V1_HUE_MAX,
-  LIGHT_COLOUR_DATA_V1_SATURATION_MIN,
-  LIGHT_COLOUR_DATA_V1_SATURATION_MAX,
-  LIGHT_COLOUR_DATA_V1_VALUE_MIN,
-  LIGHT_COLOUR_DATA_V1_VALUE_MAX,
-
-  LIGHT_COLOUR_DATA_V2_HUE_MIN,
-  LIGHT_COLOUR_DATA_V2_HUE_MAX,
-  LIGHT_COLOUR_DATA_V2_SATURATION_MIN,
-  LIGHT_COLOUR_DATA_V2_SATURATION_MAX,
-  LIGHT_COLOUR_DATA_V2_VALUE_MIN,
-  LIGHT_COLOUR_DATA_V2_VALUE_MAX,
-
-  LIGHT_TEMP_VALUE_V1_MIN,
-  LIGHT_TEMP_VALUE_V1_MAX,
-  LIGHT_TEMP_VALUE_V2_MIN,
-  LIGHT_TEMP_VALUE_V2_MAX,
-
-  LIGHT_BRIGHT_VALUE_V1_MIN,
-  LIGHT_BRIGHT_VALUE_V1_MAX,
-
-  LIGHT_BRIGHT_VALUE_V2_MIN,
-  LIGHT_BRIGHT_VALUE_V2_MAX,
-} = TuyaOAuth2Constants;
 
 /**
  * Device Class for Tuya Lights
@@ -39,19 +11,37 @@ const {
  */
 class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
 
-  constructor(...props) {
-    super(...props);
+  LIGHT_COLOUR_DATA_V1_HUE_MIN = this.store.tuya_colour?.h?.min;
+  LIGHT_COLOUR_DATA_V1_HUE_MAX = this.store.tuya_colour?.h?.max;
+  LIGHT_COLOUR_DATA_V1_SATURATION_MIN = this.store.tuya_colour?.s?.min;
+  LIGHT_COLOUR_DATA_V1_SATURATION_MAX = this.store.tuya_colour?.s?.max;
+  LIGHT_COLOUR_DATA_V1_VALUE_MIN = this.store.tuya_colour?.v?.min;
+  LIGHT_COLOUR_DATA_V1_VALUE_MAX = this.store.tuya_colour?.v?.max;
 
-    this.onCapabilityOnOff = this.onCapabilityOnOff.bind(this);
-    this.onCapabilitiesLight = this.onCapabilitiesLight.bind(this);
-  }
+  LIGHT_COLOUR_DATA_V2_HUE_MIN = this.store.tuya_colour_v2?.h?.min;
+  LIGHT_COLOUR_DATA_V2_HUE_MAX = this.store.tuya_colour_v2?.h?.max;
+  LIGHT_COLOUR_DATA_V2_SATURATION_MIN = this.store.tuya_colour_v2?.s?.min;
+  LIGHT_COLOUR_DATA_V2_SATURATION_MAX = this.store.tuya_colour_v2?.s?.max;
+  LIGHT_COLOUR_DATA_V2_VALUE_MIN = this.store.tuya_colour_v2?.v?.min;
+  LIGHT_COLOUR_DATA_V2_VALUE_MAX = this.store.tuya_colour_v2?.v?.max;
+
+  LIGHT_TEMP_VALUE_V1_MIN = this.store.tuya_temperature?.min;
+  LIGHT_TEMP_VALUE_V1_MAX = this.store.tuya_temperature?.max;
+  LIGHT_TEMP_VALUE_V2_MIN = this.store.tuya_temperature_v2?.min;
+  LIGHT_TEMP_VALUE_V2_MAX = this.store.tuya_temperature_v2?.max;
+
+  LIGHT_BRIGHT_VALUE_V1_MIN = this.store.tuya_brightness?.min;
+  LIGHT_BRIGHT_VALUE_V1_MAX = this.store.tuya_brightness?.max;
+
+  LIGHT_BRIGHT_VALUE_V2_MIN = this.store.tuya_brightness_v2?.min;
+  LIGHT_BRIGHT_VALUE_V2_MAX = this.store.tuya_brightness_v2?.max;
 
   async onOAuth2Init() {
     await super.onOAuth2Init();
 
     // onoff
     if (this.hasCapability('onoff')) {
-      this.registerCapabilityListener('onoff', this.onCapabilityOnOff);
+      this.registerCapabilityListener('onoff', value => this.onCapabilityOnOff(value));
     }
 
     // light capabilities
@@ -63,7 +53,7 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     if (this.hasCapability('light_mode')) lightCapabilities.push('light_mode');
 
     if (lightCapabilities.length > 0) {
-      this.registerMultipleCapabilityListener(lightCapabilities, this.onCapabilitiesLight, 150);
+      this.registerMultipleCapabilityListener(lightCapabilities, capabilityValues => this.onCapabilitiesLight(capabilityValues), 150);
     }
   }
 
@@ -77,29 +67,29 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
 
     // light_temperature
     if (typeof status['temp_value'] === 'number') {
-      const light_temperature = Math.min(1, Math.max(0, (status['temp_value'] - LIGHT_TEMP_VALUE_V1_MIN) / (LIGHT_TEMP_VALUE_V1_MAX - LIGHT_TEMP_VALUE_V1_MIN)));
+      const light_temperature = Math.min(1, Math.max(0, (status['temp_value'] - this.LIGHT_TEMP_VALUE_V1_MIN) / (this.LIGHT_TEMP_VALUE_V1_MAX - this.LIGHT_TEMP_VALUE_V1_MIN)));
       this.setCapabilityValue('light_temperature', light_temperature).catch(this.error);
     }
 
     if (typeof status['temp_value_v2'] === 'number') {
-      const light_temperature = Math.min(1, Math.max(0, (status['temp_value_v2'] - LIGHT_TEMP_VALUE_V2_MIN) / (LIGHT_TEMP_VALUE_V2_MAX - LIGHT_TEMP_VALUE_V2_MIN)));
+      const light_temperature = Math.min(1, Math.max(0, (status['temp_value_v2'] - this.LIGHT_TEMP_VALUE_V2_MIN) / (this.LIGHT_TEMP_VALUE_V2_MAX - this.LIGHT_TEMP_VALUE_V2_MIN)));
       this.setCapabilityValue('light_temperature', light_temperature).catch(this.error);
     }
 
     // light_hue, light_saturation
     if (status['colour_data']) {
-      const light_hue = Math.min(1, Math.max(0, (status['colour_data']['h'] - LIGHT_COLOUR_DATA_V1_HUE_MIN) / (LIGHT_COLOUR_DATA_V1_HUE_MAX - LIGHT_COLOUR_DATA_V1_HUE_MIN)));
+      const light_hue = Math.min(1, Math.max(0, (status['colour_data']['h'] - this.LIGHT_COLOUR_DATA_V1_HUE_MIN) / (this.LIGHT_COLOUR_DATA_V1_HUE_MAX - this.LIGHT_COLOUR_DATA_V1_HUE_MIN)));
       this.setCapabilityValue('light_hue', light_hue).catch(this.error);
 
-      const light_saturation = Math.min(1, Math.max(0, (status['colour_data']['s'] - LIGHT_COLOUR_DATA_V1_SATURATION_MIN) / (LIGHT_COLOUR_DATA_V1_SATURATION_MAX - LIGHT_COLOUR_DATA_V1_SATURATION_MIN)));
+      const light_saturation = Math.min(1, Math.max(0, (status['colour_data']['s'] - this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN) / (this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN)));
       this.setCapabilityValue('light_saturation', light_saturation).catch(this.error);
     }
 
     if (status['colour_data_v2']) {
-      const light_hue = Math.min(1, Math.max(0, (status['colour_data_v2']['h'] - LIGHT_COLOUR_DATA_V2_HUE_MIN) / (LIGHT_COLOUR_DATA_V2_HUE_MAX - LIGHT_COLOUR_DATA_V2_HUE_MIN)));
+      const light_hue = Math.min(1, Math.max(0, (status['colour_data_v2']['h'] - this.LIGHT_COLOUR_DATA_V2_HUE_MIN) / (this.LIGHT_COLOUR_DATA_V2_HUE_MAX - this.LIGHT_COLOUR_DATA_V2_HUE_MIN)));
       this.setCapabilityValue('light_hue', light_hue).catch(this.error);
 
-      const light_saturation = Math.min(1, Math.max(0, (status['colour_data_v2']['s'] - LIGHT_COLOUR_DATA_V2_SATURATION_MIN) / (LIGHT_COLOUR_DATA_V2_SATURATION_MAX - LIGHT_COLOUR_DATA_V2_SATURATION_MIN)));
+      const light_saturation = Math.min(1, Math.max(0, (status['colour_data_v2']['s'] - this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN) / (this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN)));
       this.setCapabilityValue('light_saturation', light_saturation).catch(this.error);
     }
 
@@ -110,12 +100,12 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
 
         // dim
         if (status['colour_data']) {
-          const dim = Math.min(1, Math.max(0, (status['colour_data']['v'] - LIGHT_COLOUR_DATA_V1_VALUE_MIN) / (LIGHT_COLOUR_DATA_V1_VALUE_MAX - LIGHT_COLOUR_DATA_V1_VALUE_MIN)));
+          const dim = Math.min(1, Math.max(0, (status['colour_data']['v'] - this.LIGHT_COLOUR_DATA_V1_VALUE_MIN) / (this.LIGHT_COLOUR_DATA_V1_VALUE_MAX - this.LIGHT_COLOUR_DATA_V1_VALUE_MIN)));
           this.setCapabilityValue('dim', dim).catch(this.error);
         }
 
         if (status['colour_data_v2']) {
-          const dim = Math.min(1, Math.max(0, (status['colour_data_v2']['v'] - LIGHT_COLOUR_DATA_V2_VALUE_MIN) / (LIGHT_COLOUR_DATA_V2_VALUE_MAX - LIGHT_COLOUR_DATA_V2_VALUE_MIN)));
+          const dim = Math.min(1, Math.max(0, (status['colour_data_v2']['v'] - this.LIGHT_COLOUR_DATA_V2_VALUE_MIN) / (this.LIGHT_COLOUR_DATA_V2_VALUE_MAX - this.LIGHT_COLOUR_DATA_V2_VALUE_MIN)));
           this.setCapabilityValue('dim', dim).catch(this.error);
         }
       }
@@ -125,24 +115,24 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
 
         // dim
         if (typeof status['bright_value'] === 'number') {
-          const dim = Math.min(1, Math.max(0, (status['bright_value'] - LIGHT_BRIGHT_VALUE_V1_MIN) / (LIGHT_BRIGHT_VALUE_V1_MAX - LIGHT_BRIGHT_VALUE_V1_MIN)));
+          const dim = Math.min(1, Math.max(0, (status['bright_value'] - this.LIGHT_BRIGHT_VALUE_V1_MIN) / (this.LIGHT_BRIGHT_VALUE_V1_MAX - this.LIGHT_BRIGHT_VALUE_V1_MIN)));
           this.setCapabilityValue('dim', dim).catch(this.error);
         }
 
         if (typeof status['bright_value_v2'] === 'number') {
-          const dim = Math.min(1, Math.max(0, (status['bright_value_v2'] - LIGHT_BRIGHT_VALUE_V2_MIN) / (LIGHT_BRIGHT_VALUE_V2_MAX - LIGHT_BRIGHT_VALUE_V2_MIN)));
+          const dim = Math.min(1, Math.max(0, (status['bright_value_v2'] - this.LIGHT_BRIGHT_VALUE_V2_MIN) / (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)));
           this.setCapabilityValue('dim', dim).catch(this.error);
         }
       }
     } else {
       // dim
       if (typeof status['bright_value'] === 'number') {
-        const dim = Math.min(1, Math.max(0, (status['bright_value'] - LIGHT_BRIGHT_VALUE_V1_MIN) / (LIGHT_BRIGHT_VALUE_V1_MAX - LIGHT_BRIGHT_VALUE_V1_MIN)));
+        const dim = Math.min(1, Math.max(0, (status['bright_value'] - this.LIGHT_BRIGHT_VALUE_V1_MIN) / (this.LIGHT_BRIGHT_VALUE_V1_MAX - this.LIGHT_BRIGHT_VALUE_V1_MIN)));
         this.setCapabilityValue('dim', dim).catch(this.error);
       }
 
       if (typeof status['bright_value_v2'] === 'number') {
-        const dim = Math.min(1, Math.max(0, (status['bright_value_v2'] - LIGHT_BRIGHT_VALUE_V2_MIN) / (LIGHT_BRIGHT_VALUE_V2_MAX - LIGHT_BRIGHT_VALUE_V2_MIN)));
+        const dim = Math.min(1, Math.max(0, (status['bright_value_v2'] - this.LIGHT_BRIGHT_VALUE_V2_MIN) / (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)));
         this.setCapabilityValue('dim', dim).catch(this.error);
       }
     }
@@ -169,9 +159,9 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
         commands.push({
           code: 'colour_data',
           value: {
-            h: Math.min(LIGHT_COLOUR_DATA_V1_HUE_MAX, Math.max(LIGHT_COLOUR_DATA_V1_HUE_MIN, Math.round(light_hue * (LIGHT_COLOUR_DATA_V1_HUE_MAX - LIGHT_COLOUR_DATA_V1_HUE_MIN)))),
-            s: Math.min(LIGHT_COLOUR_DATA_V1_SATURATION_MAX, Math.max(LIGHT_COLOUR_DATA_V1_SATURATION_MIN, Math.round(light_saturation * (LIGHT_COLOUR_DATA_V1_SATURATION_MAX - LIGHT_COLOUR_DATA_V1_SATURATION_MIN)))),
-            v: Math.min(LIGHT_COLOUR_DATA_V1_VALUE_MAX, Math.max(LIGHT_COLOUR_DATA_V1_VALUE_MIN, Math.round(dim * (LIGHT_COLOUR_DATA_V1_VALUE_MAX - LIGHT_COLOUR_DATA_V1_VALUE_MIN)))),
+            h: Math.min(this.LIGHT_COLOUR_DATA_V1_HUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_HUE_MIN, Math.round(light_hue * (this.LIGHT_COLOUR_DATA_V1_HUE_MAX - this.LIGHT_COLOUR_DATA_V1_HUE_MIN)))),
+            s: Math.min(this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN, Math.round(light_saturation * (this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN)))),
+            v: Math.min(this.LIGHT_COLOUR_DATA_V1_VALUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_VALUE_MIN, Math.round(dim * (this.LIGHT_COLOUR_DATA_V1_VALUE_MAX - this.LIGHT_COLOUR_DATA_V1_VALUE_MIN)))),
           },
         });
       }
@@ -180,9 +170,9 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
         commands.push({
           code: 'colour_data_v2',
           value: {
-            h: Math.min(LIGHT_COLOUR_DATA_V2_HUE_MAX, Math.max(LIGHT_COLOUR_DATA_V2_HUE_MIN, Math.round(light_hue * (LIGHT_COLOUR_DATA_V2_HUE_MAX - LIGHT_COLOUR_DATA_V2_HUE_MIN)))),
-            s: Math.min(LIGHT_COLOUR_DATA_V2_SATURATION_MAX, Math.max(LIGHT_COLOUR_DATA_V2_SATURATION_MIN, Math.round(light_saturation * (LIGHT_COLOUR_DATA_V2_SATURATION_MAX - LIGHT_COLOUR_DATA_V2_SATURATION_MIN)))),
-            v: Math.min(LIGHT_COLOUR_DATA_V2_VALUE_MAX, Math.max(LIGHT_COLOUR_DATA_V2_VALUE_MIN, Math.round(dim * (LIGHT_COLOUR_DATA_V2_VALUE_MAX - LIGHT_COLOUR_DATA_V2_VALUE_MIN)))),
+            h: Math.min(this.LIGHT_COLOUR_DATA_V2_HUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_HUE_MIN, Math.round(light_hue * (this.LIGHT_COLOUR_DATA_V2_HUE_MAX - this.LIGHT_COLOUR_DATA_V2_HUE_MIN)))),
+            s: Math.min(this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN, Math.round(light_saturation * (this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN)))),
+            v: Math.min(this.LIGHT_COLOUR_DATA_V2_VALUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_VALUE_MIN, Math.round(dim * (this.LIGHT_COLOUR_DATA_V2_VALUE_MAX - this.LIGHT_COLOUR_DATA_V2_VALUE_MIN)))),
           },
         });
       }
@@ -190,34 +180,34 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
       if (this.hasTuyaCapability('bright_value')) {
         commands.push({
           code: 'bright_value',
-          value: Math.min(LIGHT_BRIGHT_VALUE_V1_MAX, Math.max(LIGHT_BRIGHT_VALUE_V1_MIN, Math.round(dim * (LIGHT_BRIGHT_VALUE_V1_MAX - LIGHT_BRIGHT_VALUE_V1_MIN)))),
+          value: Math.min(this.LIGHT_BRIGHT_VALUE_V1_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V1_MIN, Math.round(dim * (this.LIGHT_BRIGHT_VALUE_V1_MAX - this.LIGHT_BRIGHT_VALUE_V1_MIN)))),
         });
       }
 
       if (this.hasTuyaCapability('bright_value_v2')) {
         commands.push({
           code: 'bright_value_v2',
-          value: Math.min(LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(dim * (LIGHT_BRIGHT_VALUE_V2_MAX - LIGHT_BRIGHT_VALUE_V2_MIN)))),
+          value: Math.min(this.LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(dim * (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)))),
         });
       }
 
       if (this.hasTuyaCapability('temp_value')) {
         commands.push({
           code: 'temp_value',
-          value: Math.min(LIGHT_TEMP_VALUE_V1_MAX, Math.max(LIGHT_TEMP_VALUE_V1_MIN, Math.round((1 - light_temperature) * (LIGHT_TEMP_VALUE_V1_MAX - LIGHT_TEMP_VALUE_V1_MIN)))),
+          value: Math.min(this.LIGHT_TEMP_VALUE_V1_MAX, Math.max(this.LIGHT_TEMP_VALUE_V1_MIN, Math.round((1 - light_temperature) * (this.LIGHT_TEMP_VALUE_V1_MAX - this.LIGHT_TEMP_VALUE_V1_MIN)))),
         });
       }
 
       if (this.hasTuyaCapability('temp_value_v2')) {
         commands.push({
           code: 'temp_value_v2',
-          value: Math.min(LIGHT_TEMP_VALUE_V2_MAX, Math.max(LIGHT_TEMP_VALUE_V2_MIN, Math.round((1 - light_temperature) * (LIGHT_TEMP_VALUE_V2_MAX - LIGHT_TEMP_VALUE_V2_MIN)))),
+          value: Math.min(this.LIGHT_TEMP_VALUE_V2_MAX, Math.max(this.LIGHT_TEMP_VALUE_V2_MIN, Math.round((1 - light_temperature) * (this.LIGHT_TEMP_VALUE_V2_MAX - this.LIGHT_TEMP_VALUE_V2_MIN)))),
         });
       }
     } else if (this.hasCapability('dim')) {
       commands.push({
         code: 'bright_value_v2',
-        value: Math.min(LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(dim * (LIGHT_BRIGHT_VALUE_V2_MAX - LIGHT_BRIGHT_VALUE_V2_MIN)))),
+        value: Math.min(this.LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(dim * (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)))),
       });
     }
 

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -67,12 +67,12 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
 
     // light_temperature
     if (typeof status['temp_value'] === 'number') {
-      const light_temperature = Math.min(1, Math.max(0, (status['temp_value'] - this.LIGHT_TEMP_VALUE_V1_MIN) / (this.LIGHT_TEMP_VALUE_V1_MAX - this.LIGHT_TEMP_VALUE_V1_MIN)));
+      const light_temperature = Math.min(1, Math.max(0, 1 - (status['temp_value'] - this.LIGHT_TEMP_VALUE_V1_MIN) / (this.LIGHT_TEMP_VALUE_V1_MAX - this.LIGHT_TEMP_VALUE_V1_MIN)));
       this.setCapabilityValue('light_temperature', light_temperature).catch(this.error);
     }
 
     if (typeof status['temp_value_v2'] === 'number') {
-      const light_temperature = Math.min(1, Math.max(0, (status['temp_value_v2'] - this.LIGHT_TEMP_VALUE_V2_MIN) / (this.LIGHT_TEMP_VALUE_V2_MAX - this.LIGHT_TEMP_VALUE_V2_MIN)));
+      const light_temperature = Math.min(1, Math.max(0, 1 - (status['temp_value_v2'] - this.LIGHT_TEMP_VALUE_V2_MIN) / (this.LIGHT_TEMP_VALUE_V2_MAX - this.LIGHT_TEMP_VALUE_V2_MIN)));
       this.setCapabilityValue('light_temperature', light_temperature).catch(this.error);
     }
 

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -159,9 +159,9 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
         commands.push({
           code: 'colour_data',
           value: {
-            h: Math.min(this.LIGHT_COLOUR_DATA_V1_HUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_HUE_MIN, Math.round(light_hue * (this.LIGHT_COLOUR_DATA_V1_HUE_MAX - this.LIGHT_COLOUR_DATA_V1_HUE_MIN)))),
-            s: Math.min(this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN, Math.round(light_saturation * (this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN)))),
-            v: Math.min(this.LIGHT_COLOUR_DATA_V1_VALUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_VALUE_MIN, Math.round(dim * (this.LIGHT_COLOUR_DATA_V1_VALUE_MAX - this.LIGHT_COLOUR_DATA_V1_VALUE_MIN)))),
+            h: Math.min(this.LIGHT_COLOUR_DATA_V1_HUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_HUE_MIN, Math.round(this.LIGHT_COLOUR_DATA_V1_HUE_MIN + light_hue * (this.LIGHT_COLOUR_DATA_V1_HUE_MAX - this.LIGHT_COLOUR_DATA_V1_HUE_MIN)))),
+            s: Math.min(this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN, Math.round(this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN + light_saturation * (this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN)))),
+            v: Math.min(this.LIGHT_COLOUR_DATA_V1_VALUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_VALUE_MIN, Math.round(this.LIGHT_COLOUR_DATA_V1_VALUE_MIN + dim * (this.LIGHT_COLOUR_DATA_V1_VALUE_MAX - this.LIGHT_COLOUR_DATA_V1_VALUE_MIN)))),
           },
         });
       }
@@ -170,9 +170,9 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
         commands.push({
           code: 'colour_data_v2',
           value: {
-            h: Math.min(this.LIGHT_COLOUR_DATA_V2_HUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_HUE_MIN, Math.round(light_hue * (this.LIGHT_COLOUR_DATA_V2_HUE_MAX - this.LIGHT_COLOUR_DATA_V2_HUE_MIN)))),
-            s: Math.min(this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN, Math.round(light_saturation * (this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN)))),
-            v: Math.min(this.LIGHT_COLOUR_DATA_V2_VALUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_VALUE_MIN, Math.round(dim * (this.LIGHT_COLOUR_DATA_V2_VALUE_MAX - this.LIGHT_COLOUR_DATA_V2_VALUE_MIN)))),
+            h: Math.min(this.LIGHT_COLOUR_DATA_V2_HUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_HUE_MIN, Math.round(this.LIGHT_COLOUR_DATA_V2_HUE_MIN + light_hue * (this.LIGHT_COLOUR_DATA_V2_HUE_MAX - this.LIGHT_COLOUR_DATA_V2_HUE_MIN)))),
+            s: Math.min(this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN, Math.round(this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN + light_saturation * (this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN)))),
+            v: Math.min(this.LIGHT_COLOUR_DATA_V2_VALUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_VALUE_MIN, Math.round( this.LIGHT_COLOUR_DATA_V2_VALUE_MIN + dim * (this.LIGHT_COLOUR_DATA_V2_VALUE_MAX - this.LIGHT_COLOUR_DATA_V2_VALUE_MIN)))),
           },
         });
       }
@@ -180,34 +180,34 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
       if (this.hasTuyaCapability('bright_value')) {
         commands.push({
           code: 'bright_value',
-          value: Math.min(this.LIGHT_BRIGHT_VALUE_V1_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V1_MIN, Math.round(dim * (this.LIGHT_BRIGHT_VALUE_V1_MAX - this.LIGHT_BRIGHT_VALUE_V1_MIN)))),
+          value: Math.min(this.LIGHT_BRIGHT_VALUE_V1_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V1_MIN, Math.round(this.LIGHT_BRIGHT_VALUE_V1_MIN + dim * (this.LIGHT_BRIGHT_VALUE_V1_MAX - this.LIGHT_BRIGHT_VALUE_V1_MIN)))),
         });
       }
 
       if (this.hasTuyaCapability('bright_value_v2')) {
         commands.push({
           code: 'bright_value_v2',
-          value: Math.min(this.LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(dim * (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)))),
+          value: Math.min(this.LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(this.LIGHT_BRIGHT_VALUE_V2_MIN + dim * (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)))),
         });
       }
 
       if (this.hasTuyaCapability('temp_value')) {
         commands.push({
           code: 'temp_value',
-          value: Math.min(this.LIGHT_TEMP_VALUE_V1_MAX, Math.max(this.LIGHT_TEMP_VALUE_V1_MIN, Math.round((1 - light_temperature) * (this.LIGHT_TEMP_VALUE_V1_MAX - this.LIGHT_TEMP_VALUE_V1_MIN)))),
+          value: Math.min(this.LIGHT_TEMP_VALUE_V1_MAX, Math.max(this.LIGHT_TEMP_VALUE_V1_MIN, Math.round(this.LIGHT_TEMP_VALUE_V1_MIN + (1 - light_temperature) * (this.LIGHT_TEMP_VALUE_V1_MAX - this.LIGHT_TEMP_VALUE_V1_MIN)))),
         });
       }
 
       if (this.hasTuyaCapability('temp_value_v2')) {
         commands.push({
           code: 'temp_value_v2',
-          value: Math.min(this.LIGHT_TEMP_VALUE_V2_MAX, Math.max(this.LIGHT_TEMP_VALUE_V2_MIN, Math.round((1 - light_temperature) * (this.LIGHT_TEMP_VALUE_V2_MAX - this.LIGHT_TEMP_VALUE_V2_MIN)))),
+          value: Math.min(this.LIGHT_TEMP_VALUE_V2_MAX, Math.max(this.LIGHT_TEMP_VALUE_V2_MIN, Math.round(this.LIGHT_TEMP_VALUE_V2_MIN + (1 - light_temperature) * (this.LIGHT_TEMP_VALUE_V2_MAX - this.LIGHT_TEMP_VALUE_V2_MIN)))),
         });
       }
     } else if (this.hasCapability('dim')) {
       commands.push({
         code: 'bright_value_v2',
-        value: Math.min(this.LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(dim * (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)))),
+        value: Math.min(this.LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(this.LIGHT_BRIGHT_VALUE_V2_MIN + dim * (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)))),
       });
     }
 

--- a/lib/TuyaOAuth2Driver.js
+++ b/lib/TuyaOAuth2Driver.js
@@ -12,12 +12,16 @@ class TuyaOAuth2Driver extends OAuth2Driver {
 
   async onPairListDevices({ oAuth2Client }) {
     const devices = await oAuth2Client.getDevices();
-    return devices
+    const filteredDevices = devices
       .filter(device => {
         this.log('Device:', JSON.stringify(device));
         return this.onTuyaPairListDeviceFilter(device);
-      })
-      .map(device => ({
+      });
+    const listDevices = [];
+    for (const device of filteredDevices) {
+      const deviceSpecs = await oAuth2Client.getSpecification({deviceId: device.id});
+      const deviceProperties = this.onTuyaPairListDeviceProperties({...device}, deviceSpecs);
+      listDevices.push({
         name: device.name,
         data: {
           deviceId: device.id,
@@ -26,8 +30,10 @@ class TuyaOAuth2Driver extends OAuth2Driver {
         store: {},
         capabilities: [],
         capabilitiesOptions: {},
-        ...this.onTuyaPairListDeviceProperties({ ...device }),
-      }));
+        ...deviceProperties,
+      });
+    }
+    return listDevices;
   }
 
   onTuyaPairListDeviceFilter(device) {

--- a/lib/TuyaOAuth2Driver.js
+++ b/lib/TuyaOAuth2Driver.js
@@ -46,6 +46,7 @@ class TuyaOAuth2Driver extends OAuth2Driver {
       store: {
         tuya_capabilities: [],
       },
+      capabilitiesOptions: {},
     };
 
     return props;

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -27,7 +27,7 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     // onoff
     const hasSwitchLed = device.status.some(({ code }) => code === 'switch_led');
     if (hasSwitchLed) {
-      props.store.tuya_capabilities.push('bright_value');
+      props.store.tuya_capabilities.push('switch_led');
       props.capabilities.push('onoff');
     }
 

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -21,7 +21,7 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     // TODO
   ];
 
-  onTuyaPairListDeviceProperties(device) {
+  onTuyaPairListDeviceProperties(device, specifications) {
     const props = super.onTuyaPairListDeviceProperties(device);
 
     // onoff
@@ -77,6 +77,26 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     if (hasWorkMode) {
       props.store.tuya_capabilities.push('work_mode');
       props.capabilities.push('light_mode');
+    }
+
+    // Specifications
+    for (const functionSpecification of specifications.functions) {
+      const tuyaCapability = functionSpecification.code;
+      const values = JSON.parse(functionSpecification.values);
+
+      if (tuyaCapability === 'bright_value') {
+        props.store.tuya_brightness = values;
+      } else if (tuyaCapability === 'bright_value_v2') {
+        props.store.tuya_brightness_v2 = values;
+      } else if (tuyaCapability === 'temp_value') {
+        props.store.tuya_temperature = values;
+      } else if (tuyaCapability === 'temp_value_v2') {
+        props.store.tuya_temperature_v2 = values;
+      } else if (tuyaCapability === 'colour_data') {
+        props.store.tuya_colour = values;
+      } else if (tuyaCapability === 'colour_data_v2') {
+        props.store.tuya_colour_v2 = values;
+      }
     }
 
     return props;

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -76,7 +76,11 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     const hasWorkMode = device.status.some(({ code }) => code === 'work_mode');
     if (hasWorkMode) {
       props.store.tuya_capabilities.push('work_mode');
-      props.capabilities.push('light_mode');
+
+      // Only add light mode capability when both temperature and colour data is available
+      if ((hasTemperatureValue || hasTemperatureValueV2) && (hasColourData || hasColourDataV2)) {
+        props.capabilities.push('light_mode');
+      }
     }
 
     // Specifications


### PR DESCRIPTION
**- Fixed light data mismatch between Tuya and Homey**
     The constants that were used were not always correct,
     as Tuya uses the same property names with different definitions between light subclasses.
     The definitions are now retrieved from the device specification,
     so they should always match the device itself, independent of its class.
     This fixes problems with colors etc. not matching,
     but it is also a breaking change for people already testing the app with their lights.

**- Fixed an incorrect capability in pairing**
    Instead of the switch_led Tuya capability bright_value was added.
    This meant that devices using bright_value_v2 were sending data twice,
    causing errors and making the Homey temperature picker bug out.
    This fix also requires repairing lights already being tested.

**- Fixed range conversion for sending light data**
    Range conversions did not include minima, causing lower values than intended.
    This caused things like brightness to be decreased every time it was sent,
    even as part of light temperature settings etc.

**- Fixed inconsistent inversion of light temperature values**
    Light temperature values were correctly inverted when sending, but not receiving.
    This caused the temperature picker to jump to the opposite side of the spectrum after every adjustment.
