### PR TITLE
Add setting to scale socket power measurement

### DIFF
--- a/app.json
+++ b/app.json
@@ -763,7 +763,34 @@
         "en": "Plug",
         "nl": "Plug"
       },
-      "id": "socket"
+      "id": "socket",
+      "settings": [
+        {
+          "id": "power_scaling",
+          "type": "dropdown",
+          "label": {
+            "en": "Power Measurement Scale"
+          },
+          "hint": {
+            "en": "By how much the power reported by the device is scaled."
+          },
+          "value": "0",
+          "values": [
+            {
+              "id": "0",
+              "label": {
+                "en": "1"
+              }
+            },
+            {
+              "id": "1",
+              "label": {
+                "en": "1/10"
+              }
+            }
+          ]
+        }
+      ]
     }
   ]
 }

--- a/drivers/socket/driver.settings.compose.json
+++ b/drivers/socket/driver.settings.compose.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "power_scaling",
+    "type": "dropdown",
+    "label": {
+      "en": "Power Measurement Scale"
+    },
+    "hint": {
+      "en": "By how much the power reported by the device is scaled."
+    },
+    "value": "0",
+    "values": [
+      {
+        "id": "0",
+        "label": {
+          "en": "1"
+        }
+      },
+      {
+        "id": "1",
+        "label": {
+          "en": "1/10"
+        }
+      }
+    ]
+  }
+]

--- a/lib/TuyaOAuth2DeviceSocket.js
+++ b/lib/TuyaOAuth2DeviceSocket.js
@@ -67,7 +67,8 @@ class TuyaOAuth2DeviceSocket extends TuyaOAuth2Device {
     this.safeSetCapabilityValue('onoff', anySwitchOn).catch(this.error);
 
     if (typeof status['cur_power'] === 'number') {
-      const cur_power = status['cur_power'];
+      const powerScaling = 10 ** parseFloat(this.getSetting('power_scaling') ?? "0");
+      const cur_power = status['cur_power'] / powerScaling;
       this.setCapabilityValue('measure_power', cur_power).catch(this.error);
     }
 


### PR DESCRIPTION
Fixes #42 

**Added setting to scale socket power measurement**
Some device implementations differ from the documentation in the factor by which measured power is scaled.
Since this factor cannot reliably be retrieved from the device state or specification a setting was deemed the most straightforward fix.