### PR TITLE
Expand lights

### DIFF
--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -1,4 +1,6 @@
 {
   "device_offline": "The device seems to be offline. Is it powered on, and connected to the internet?",
-  "switch": "Switch __number__"
+  "switch": "Switch __number__",
+  "settings_unsupported": "Some of the changed settings are not supported by the device:",
+  "setting_values_unsupported": "Some of the changed values are not supported by the device:"
 }

--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -2,5 +2,7 @@
   "device_offline": "The device seems to be offline. Is it powered on, and connected to the internet?",
   "switch": "Switch __number__",
   "settings_unsupported": "Some of the changed settings are not supported by the device:",
-  "setting_values_unsupported": "Some of the changed values are not supported by the device:"
+  "setting_values_unsupported": "Some of the changed values are not supported by the device:",
+  "setting_unsupported": "__label__ is not supported by the device",
+  "setting_value_unsupported": "Value is not supported for __label__ by the device"
 }

--- a/app.json
+++ b/app.json
@@ -455,6 +455,52 @@
         "id": "send_command_string"
       },
       {
+        "id": "light_switch_pir",
+        "title": {
+          "en": "Set motion detection"
+        },
+        "titleFormatted": {
+          "en": "Set motion detection [[value]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=alarm_motion"
+          },
+          {
+            "name": "value",
+            "type": "checkbox",
+            "title": {
+              "en": "Value"
+            }
+          }
+        ]
+      },
+      {
+        "id": "light_standby_on",
+        "title": {
+          "en": "Set standby light"
+        },
+        "titleFormatted": {
+          "en": "Set standby light [[value]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light"
+          },
+          {
+            "name": "value",
+            "type": "checkbox",
+            "title": {
+              "en": "Value"
+            }
+          }
+        ]
+      },
+      {
         "id": "socket_sub_switch_off",
         "highlight": true,
         "title": {

--- a/app.json
+++ b/app.json
@@ -485,6 +485,9 @@
         "titleFormatted": {
           "en": "Set standby light [[value]]"
         },
+        "hint": {
+          "en": "CAUTION: This setting is not supported by every light."
+        },
         "args": [
           {
             "type": "device",

--- a/app.json
+++ b/app.json
@@ -771,7 +771,158 @@
         "en": "Light",
         "nl": "Lamp"
       },
-      "id": "light"
+      "id": "light",
+      "settings": [
+        {
+          "type": "group",
+          "label": {
+            "en": "CAUTION: Some settings are not supported by every light."
+          },
+          "children": [
+            {
+              "id": "switch_pir",
+              "type": "checkbox",
+              "label": {
+                "en": "Motion Detection"
+              },
+              "value": false
+            },
+            {
+              "id": "pir_sensitivity",
+              "type": "dropdown",
+              "label": {
+                "en": "Motion Sensitivity"
+              },
+              "value": "middle",
+              "values": [
+                {
+                  "id": "low",
+                  "label": {
+                    "en": "Low"
+                  }
+                },
+                {
+                  "id": "middle",
+                  "label": {
+                    "en": "Middle"
+                  }
+                },
+                {
+                  "id": "high",
+                  "label": {
+                    "en": "High"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "pir_delay",
+              "type": "number",
+              "label": {
+                "en": "Motion Trigger Period"
+              },
+              "hint": {
+                "en": "For how long the motion detection stays in the triggered state before going to the standby state."
+              },
+              "value": 20,
+              "min": 5,
+              "max": 3600,
+              "step": 1,
+              "units": {
+                "en": "seconds"
+              }
+            },
+            {
+              "id": "cds",
+              "type": "dropdown",
+              "label": {
+                "en": "Luminance Detection"
+              },
+              "hint": {
+                "en": "At what brightness the light can be triggered."
+              },
+              "value": "10lux",
+              "values": [
+                {
+                  "id": "5lux",
+                  "label": {
+                    "en": "5 Lux"
+                  }
+                },
+                {
+                  "id": "10lux",
+                  "label": {
+                    "en": "10 Lux"
+                  }
+                },
+                {
+                  "id": "300lux",
+                  "label": {
+                    "en": "300 Lux"
+                  }
+                },
+                {
+                  "id": "2000lux",
+                  "label": {
+                    "en": "2000 Lux"
+                  }
+                },
+                {
+                  "id": "now",
+                  "label": {
+                    "en": "Now"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "standby_on",
+              "type": "checkbox",
+              "label": {
+                "en": "Standby Light"
+              },
+              "hint": {
+                "en": "Whether the device stays in standby state after the trigger period is over."
+              },
+              "value": false
+            },
+            {
+              "id": "standby_time",
+              "type": "number",
+              "label": {
+                "en": "Standby Time"
+              },
+              "hint": {
+                "en": "How long the device stays in standby state after the trigger period is over."
+              },
+              "value": 360,
+              "min": 1,
+              "max": 480,
+              "step": 1,
+              "units": {
+                "en": "minutes"
+              }
+            },
+            {
+              "id": "standby_bright",
+              "type": "number",
+              "label": {
+                "en": "Standby Brightness"
+              },
+              "hint": {
+                "en": "How bright the device stays in standby state after the trigger period is over."
+              },
+              "value": 0,
+              "min": 0,
+              "max": 100,
+              "step": 0.1,
+              "units": {
+                "en": "%"
+              }
+            }
+          ]
+        }
+      ]
     },
     {
       "capabilities": [],

--- a/drivers/light/driver.flow.compose.json
+++ b/drivers/light/driver.flow.compose.json
@@ -1,0 +1,39 @@
+{
+  "actions": [
+    {
+      "id": "light_switch_pir",
+      "$filter": "capabilities=alarm_motion",
+      "title": {
+        "en": "Set motion detection"
+      },
+      "titleFormatted": {
+        "en": "Set motion detection [[value]]"
+      },
+      "args": [
+        {
+          "name": "value",
+          "type": "checkbox",
+          "title": { "en": "Value" }
+        }
+      ]
+    },
+    {
+      "id": "light_standby_on",
+      "title": {
+        "en": "Set standby light"
+      },
+      "titleFormatted": {
+        "en": "Set standby light [[value]]"
+      },
+      "args": [
+        {
+          "name": "value",
+          "type": "checkbox",
+          "title": { "en": "Value" }
+        }
+      ]
+    }
+  ],
+  "conditions": [],
+  "triggers": []
+}

--- a/drivers/light/driver.flow.compose.json
+++ b/drivers/light/driver.flow.compose.json
@@ -25,6 +25,9 @@
       "titleFormatted": {
         "en": "Set standby light [[value]]"
       },
+      "hint": {
+        "en": "CAUTION: This setting is not supported by every light."
+      },
       "args": [
         {
           "name": "value",
@@ -33,7 +36,5 @@
         }
       ]
     }
-  ],
-  "conditions": [],
-  "triggers": []
+  ]
 }

--- a/drivers/light/driver.settings.compose.json
+++ b/drivers/light/driver.settings.compose.json
@@ -1,0 +1,145 @@
+[
+  {
+    "type": "group",
+    "label": {
+      "en": "CAUTION: Some settings are not supported by every light."
+    },
+    "children": [
+      {
+        "id": "switch_pir",
+        "type": "checkbox",
+        "label": {
+          "en": "Motion Detection"
+        },
+        "value": false
+      },
+      {
+        "id": "pir_sensitivity",
+        "type": "dropdown",
+        "label": {
+          "en": "Motion Sensitivity"
+        },
+        "value": "middle",
+        "values": [
+          {
+            "id": "low",
+            "label": {
+              "en": "Low"
+            }
+          },
+          {
+            "id": "middle",
+            "label": {
+              "en": "Middle"
+            }
+          },
+          {
+            "id": "high",
+            "label": {
+              "en": "High"
+            }
+          }
+        ]
+      },
+      {
+        "id": "pir_delay",
+        "type": "number",
+        "label": {
+          "en": "Motion Trigger Period"
+        },
+        "hint": {
+          "en": "For how long the motion detection stays in the triggered state before going to the standby state."
+        },
+        "value": 20,
+        "min": 5,
+        "max": 3600,
+        "step": 1,
+        "units": { "en": "seconds" }
+      },
+      {
+        "id": "cds",
+        "type": "dropdown",
+        "label": {
+          "en": "Luminance Detection"
+        },
+        "hint": {
+          "en": "At what brightness the light can be triggered."
+        },
+        "value": "10lux",
+        "values": [
+          {
+            "id": "5lux",
+            "label": {
+              "en": "5 Lux"
+            }
+          },
+          {
+            "id": "10lux",
+            "label": {
+              "en": "10 Lux"
+            }
+          },
+          {
+            "id": "300lux",
+            "label": {
+              "en": "300 Lux"
+            }
+          },
+          {
+            "id": "2000lux",
+            "label": {
+              "en": "2000 Lux"
+            }
+          },
+          {
+            "id": "now",
+            "label": {
+              "en": "Now"
+            }
+          }
+        ]
+      },
+      {
+        "id": "standby_on",
+        "type": "checkbox",
+        "label": {
+          "en": "Standby Light"
+        },
+        "hint": {
+          "en": "Whether the device stays in standby state after the trigger period is over."
+        },
+        "value": false
+      },
+      {
+        "id": "standby_time",
+        "type": "number",
+        "label": {
+          "en": "Standby Time"
+        },
+        "hint": {
+          "en": "How long the device stays in standby state after the trigger period is over."
+        },
+        "value": 360,
+        "min": 1,
+        "max": 480,
+        "step": 1,
+        "units": { "en": "minutes" }
+      },
+      {
+        "id": "standby_bright",
+        "type": "number",
+        "label": {
+          "en": "Standby Brightness"
+        },
+        "hint": {
+          "en": "How bright the device stays in standby state after the trigger period is over."
+        },
+        "value": 0,
+        "min": 0,
+        "max": 100,
+        "step": 0.1,
+        "units": { "en": "%" }
+      }
+    ]
+  }
+]

--- a/lib/TuyaLightConstants.js
+++ b/lib/TuyaLightConstants.js
@@ -1,0 +1,27 @@
+'use strict'
+
+class TuyaLightConstants {
+  static PIR_CAPABILITIES = {
+    read_write: [],
+    read_only: ['pir_state'],
+    setting: [
+      'switch_pir', // Turn motion detection on/off
+      'pir_delay', // change motion detection duration
+      'pir_sensitivity', // Change motion detection level
+      'cds', // Change luminance detection level
+      'standby_time', // Change standby duration
+    ],
+  }
+
+  static LIGHT_SETTING_LABELS = {
+    switch_pir: "Motion Detection",
+    pir_sensitivity: "Motion Sensitivity",
+    pir_delay: "Motion Delay",
+    cds: "Luminance Detection",
+    standby_on: "Standby Light",
+    standby_time: "Standby Time",
+    standby_bright: "Standby Brightness",
+  }
+}
+
+module.exports = TuyaLightConstants;

--- a/lib/TuyaOAuth2Constants.js
+++ b/lib/TuyaOAuth2Constants.js
@@ -220,34 +220,8 @@ class TuyaOAuth2Constants {
     DEVICE_NAME_EXIST: 2101, // this device name already exists
   };
 
-  // Light
-  // Source: https://developer.tuya.com/en/docs/iot/dj?id=K9i5ql3v98hn3
-  static LIGHT_COLOUR_DATA_V1_HUE_MIN = 0;
-  static LIGHT_COLOUR_DATA_V1_HUE_MAX = 360;
-  static LIGHT_COLOUR_DATA_V1_SATURATION_MIN = 0;
-  static LIGHT_COLOUR_DATA_V1_SATURATION_MAX = 255;
-  static LIGHT_COLOUR_DATA_V1_VALUE_MIN = 0;
-  static LIGHT_COLOUR_DATA_V1_VALUE_MAX = 255;
-
-  static LIGHT_COLOUR_DATA_V2_HUE_MIN = 0;
-  static LIGHT_COLOUR_DATA_V2_HUE_MAX = 360;
-  static LIGHT_COLOUR_DATA_V2_SATURATION_MIN = 0;
-  static LIGHT_COLOUR_DATA_V2_SATURATION_MAX = 1000;
-  static LIGHT_COLOUR_DATA_V2_VALUE_MIN = 0;
-  static LIGHT_COLOUR_DATA_V2_VALUE_MAX = 1000;
-
-  static LIGHT_TEMP_VALUE_V1_MIN = 25;
-  static LIGHT_TEMP_VALUE_V1_MAX = 255;
-
-  static LIGHT_TEMP_VALUE_V2_MIN = 0;
-  static LIGHT_TEMP_VALUE_V2_MAX = 1000;
-
-  static LIGHT_BRIGHT_VALUE_V1_MIN = 25;
-  static LIGHT_BRIGHT_VALUE_V1_MAX = 255;
-
-  static LIGHT_BRIGHT_VALUE_V2_MIN = 10;
-  static LIGHT_BRIGHT_VALUE_V2_MAX = 1000;
-
+  // From (0,100) in Homey to (0,1000) in Tuya
+  static TUYA_PERCENTAGE_SCALING = 10;
 }
 
 module.exports = TuyaOAuth2Constants;

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -155,12 +155,10 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
       }
     }
 
-    if (status['pir_state'] !== undefined) {
-      if (this.hasCapability('alarm_motion')) {
-        const pirTurnedOn = status['switch_pir'] || !this.store.tuya_capabilities.includes('switch_pir');
-        const newPirState = status['pir_state'] === 'pir' && pirTurnedOn;
-        this.setCapabilityValue('alarm_motion', newPirState).catch(this.error)
-      }
+    if (status['pir_state'] !== undefined && this.hasCapability('alarm_motion')) {
+      const pirTurnedOn = status['switch_pir'] || !this.store.tuya_capabilities.includes('switch_pir');
+      const newPirState = status['pir_state'] === 'pir' && pirTurnedOn;
+      this.setCapabilityValue('alarm_motion', newPirState).catch(this.error)
     }
 
     if (status['standby_on'] !== undefined || status['standby_bright'] !== undefined) {
@@ -337,6 +335,7 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
       const newValue = newSettings[changedKey];
 
       if (changedKey === 'standby_on' || changedKey === 'standby_bright') {
+        // Only send the standby commands once for both settings
         if (changedStandby) {
           continue;
         } else {
@@ -379,22 +378,16 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     const messages = [];
 
     if (unsupportedSettings.length > 0) {
-      let unsupportedSettingsMessage =
-        this.homey.__("settings_unsupported") + " ";
       const mappedSettingNames = unsupportedSettings.map(
         (settingKey) => LIGHT_SETTING_LABELS[settingKey],
       );
-      unsupportedSettingsMessage += mappedSettingNames.join(", ");
-      messages.push(unsupportedSettingsMessage);
+      messages.push(this.homey.__("settings_unsupported") + " " + mappedSettingNames.join(", "));
     }
     if (unsupportedValues.length > 0) {
-      let unsupportedValuesMessage =
-        this.homey.__("setting_values_unsupported") + " ";
       const mappedSettingNames = unsupportedValues.map(
         (settingKey) => LIGHT_SETTING_LABELS[settingKey],
       );
-      unsupportedValuesMessage += mappedSettingNames.join(", ");
-      messages.push(unsupportedValuesMessage);
+      messages.push(this.homey.__("setting_values_unsupported") + " " + mappedSettingNames.join(", "));
     }
     if (messages.length > 0) {
       return messages.join("\n");

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -220,10 +220,19 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
         });
       }
     } else if (this.hasCapability('dim')) {
-      commands.push({
-        code: 'bright_value_v2',
-        value: Math.min(this.LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(this.LIGHT_BRIGHT_VALUE_V2_MIN + dim * (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)))),
-      });
+      if (this.hasTuyaCapability('bright_value')) {
+        commands.push({
+          code: 'bright_value',
+          value: Math.min(this.LIGHT_BRIGHT_VALUE_V1_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V1_MIN, Math.round(this.LIGHT_BRIGHT_VALUE_V1_MIN + dim * (this.LIGHT_BRIGHT_VALUE_V1_MAX - this.LIGHT_BRIGHT_VALUE_V1_MIN)))),
+        });
+      }
+
+      if (this.hasTuyaCapability('bright_value_v2')) {
+        commands.push({
+          code: 'bright_value_v2',
+          value: Math.min(this.LIGHT_BRIGHT_VALUE_V2_MAX, Math.max(this.LIGHT_BRIGHT_VALUE_V2_MIN, Math.round(this.LIGHT_BRIGHT_VALUE_V2_MIN + dim * (this.LIGHT_BRIGHT_VALUE_V2_MAX - this.LIGHT_BRIGHT_VALUE_V2_MIN)))),
+        });
+      }
     }
 
     if (commands.length) {

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -174,7 +174,8 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
           value: {
             h: Math.min(this.LIGHT_COLOUR_DATA_V1_HUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_HUE_MIN, Math.round(this.LIGHT_COLOUR_DATA_V1_HUE_MIN + light_hue * (this.LIGHT_COLOUR_DATA_V1_HUE_MAX - this.LIGHT_COLOUR_DATA_V1_HUE_MIN)))),
             s: Math.min(this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN, Math.round(this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN + light_saturation * (this.LIGHT_COLOUR_DATA_V1_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V1_SATURATION_MIN)))),
-            v: Math.min(this.LIGHT_COLOUR_DATA_V1_VALUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V1_VALUE_MIN, Math.round(this.LIGHT_COLOUR_DATA_V1_VALUE_MIN + dim * (this.LIGHT_COLOUR_DATA_V1_VALUE_MAX - this.LIGHT_COLOUR_DATA_V1_VALUE_MIN)))),
+            // Prevent a value of 0, which causes unwanted behavior
+            v: Math.min(this.LIGHT_COLOUR_DATA_V1_VALUE_MAX, Math.max(1, this.LIGHT_COLOUR_DATA_V1_VALUE_MIN, Math.round(this.LIGHT_COLOUR_DATA_V1_VALUE_MIN + dim * (this.LIGHT_COLOUR_DATA_V1_VALUE_MAX - this.LIGHT_COLOUR_DATA_V1_VALUE_MIN)))),
           },
         });
       }
@@ -185,7 +186,8 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
           value: {
             h: Math.min(this.LIGHT_COLOUR_DATA_V2_HUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_HUE_MIN, Math.round(this.LIGHT_COLOUR_DATA_V2_HUE_MIN + light_hue * (this.LIGHT_COLOUR_DATA_V2_HUE_MAX - this.LIGHT_COLOUR_DATA_V2_HUE_MIN)))),
             s: Math.min(this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN, Math.round(this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN + light_saturation * (this.LIGHT_COLOUR_DATA_V2_SATURATION_MAX - this.LIGHT_COLOUR_DATA_V2_SATURATION_MIN)))),
-            v: Math.min(this.LIGHT_COLOUR_DATA_V2_VALUE_MAX, Math.max(this.LIGHT_COLOUR_DATA_V2_VALUE_MIN, Math.round( this.LIGHT_COLOUR_DATA_V2_VALUE_MIN + dim * (this.LIGHT_COLOUR_DATA_V2_VALUE_MAX - this.LIGHT_COLOUR_DATA_V2_VALUE_MIN)))),
+            // Prevent a value of 0, which causes unwanted behavior
+            v: Math.min(this.LIGHT_COLOUR_DATA_V2_VALUE_MAX, Math.max(1, this.LIGHT_COLOUR_DATA_V2_VALUE_MIN, Math.round( this.LIGHT_COLOUR_DATA_V2_VALUE_MIN + dim * (this.LIGHT_COLOUR_DATA_V2_VALUE_MAX - this.LIGHT_COLOUR_DATA_V2_VALUE_MIN)))),
           },
         });
       }

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -289,6 +289,31 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     }
   }
 
+  async sendSettingCommand({code, value}) {
+    await this
+      .sendCommand({
+        code: code,
+        value: value,
+      })
+      .catch((err) => {
+        if (err.tuyaCode === 2008) {
+          throw new Error(
+            this.homey.__("setting_unsupported", {
+              label: LIGHT_SETTING_LABELS[code],
+            }),
+          );
+        } else if (err.tuyaCode === 501) {
+          throw new Error(
+            this.homey.__("setting_value_unsupported", {
+              label: LIGHT_SETTING_LABELS[code],
+            }),
+          );
+        } else {
+          throw err;
+        }
+      });
+  }
+
   async onSettings({ oldSettings, newSettings, changedKeys }) {
     const unsupportedSettings = [];
     const unsupportedValues = [];

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -3,10 +3,8 @@
 'use strict';
 
 const TuyaOAuth2Device = require('./TuyaOAuth2Device');
-const { PIR_CAPABILITIES, LIGHT_SETTING_LABELS } = require('./TuyaOAuth2DriverLight');
-
-// From (0,100) in Homey to (0,1000) in Tuya
-const TUYA_PERCENTAGE_SCALING = 10;
+const {PIR_CAPABILITIES, LIGHT_SETTING_LABELS} = require('./TuyaLightConstants');
+const {TUYA_PERCENTAGE_SCALING} = require('./TuyaOAuth2Constants');
 
 /**
  * Device Class for Tuya Lights

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -318,6 +318,18 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     const unsupportedSettings = [];
     const unsupportedValues = [];
 
+    // Accumulate rejected settings so the user can be notified gracefully
+    const sendSetting = async (command) =>
+      this.sendCommand(command).catch((err) => {
+        if (err.tuyaCode === 2008) {
+          unsupportedSettings.push(command.code);
+        } else if (err.tuyaCode === 501) {
+          unsupportedValues.push(command.code);
+        } else {
+          throw err;
+        }
+      });
+
     // Only send the standby commands once for both settings
     let changedStandby = false;
 
@@ -352,28 +364,12 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
         }
 
         for (const command of commands) {
-          await this.sendCommand(command).catch((err) => {
-            if (err.tuyaCode === 2008) {
-              unsupportedSettings.push(command.code);
-            } else if (err.tuyaCode === 501) {
-              unsupportedValues.push(command.code);
-            } else {
-              throw err;
-            }
-          });
+          await sendSetting(command);
         }
       } else {
-        await this.sendCommand({
+        await sendSetting({
           code: changedKey,
           value: newValue,
-        }).catch((err) => {
-          if (err.tuyaCode === 2008) {
-            unsupportedSettings.push(changedKey);
-          } else if (err.tuyaCode === 501) {
-            unsupportedValues.push(changedKey);
-          } else {
-            throw err;
-          }
         });
       }
     }

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -3,6 +3,10 @@
 'use strict';
 
 const TuyaOAuth2Device = require('./TuyaOAuth2Device');
+const { PIR_CAPABILITIES, LIGHT_SETTING_LABELS } = require('./TuyaOAuth2DriverLight');
+
+// From (0,100) in Homey to (0,1000) in Tuya
+const TUYA_PERCENTAGE_SCALING = 10;
 
 /**
  * Device Class for Tuya Lights
@@ -140,6 +144,51 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
         this.setCapabilityValue('dim', dim).catch(this.error);
       }
     }
+
+    // PIR
+    for (const pirCapability of PIR_CAPABILITIES.setting) {
+      const newValue = status[pirCapability];
+      if (newValue !== undefined) {
+        await this.setSettings({
+          [pirCapability]: newValue,
+        }).catch(this.error)
+      }
+    }
+
+    if (status['pir_state'] !== undefined) {
+      if (this.hasCapability('alarm_motion')) {
+        const pirTurnedOn = status['switch_pir'] || !this.store.tuya_capabilities.includes('switch_pir');
+        const newPirState = status['pir_state'] === 'pir' && pirTurnedOn;
+        this.setCapabilityValue('alarm_motion', newPirState).catch(this.error)
+      }
+    }
+
+    if (status['standby_on'] !== undefined || status['standby_bright'] !== undefined) {
+      const hasStandbyOn = this.store.tuya_capabilities.includes('standby_on');
+      const standbyOn = status['standby_on'];
+      const standbyBrightness = status['standby_bright'];
+      let settings = {};
+
+      if (!hasStandbyOn) {
+        if (standbyBrightness > 0) {
+          settings = {
+            'standby_on': true,
+            'standby_bright': standbyBrightness / TUYA_PERCENTAGE_SCALING,
+          }
+        } else {
+          // Keep the brightness setting for when turning standby back on
+          settings = {
+            'standby_on': false,
+          }
+        }
+      } else {
+        settings = {
+          'standby_on': standbyOn,
+          'standby_bright': standbyBrightness / TUYA_PERCENTAGE_SCALING,
+        }
+      }
+      await this.setSettings(settings).catch(this.error)
+    }
   }
 
   async onCapabilityOnOff(value) {
@@ -240,6 +289,96 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     }
   }
 
+  async onSettings({ oldSettings, newSettings, changedKeys }) {
+    const unsupportedSettings = [];
+    const unsupportedValues = [];
+
+    // Only send the standby commands once for both settings
+    let changedStandby = false;
+
+    for (const changedKey of changedKeys) {
+      const newValue = newSettings[changedKey];
+
+      if (changedKey === 'standby_on' || changedKey === 'standby_bright') {
+        if (changedStandby) {
+          continue;
+        } else {
+          changedStandby = true;
+        }
+
+        const hasStandbyOn = this.store.tuya_capabilities.includes('standby_on');
+        const standbyOn = newSettings['standby_on'];
+        const standbyBrightness = newSettings['standby_bright'];
+        let commands;
+
+        if (!hasStandbyOn) {
+          commands = [{
+            code: 'standby_bright',
+            value: standbyOn ? standbyBrightness * TUYA_PERCENTAGE_SCALING : 0,
+          }]
+        } else {
+          commands = [{
+            code: 'standby_bright',
+            value: standbyBrightness * TUYA_PERCENTAGE_SCALING,
+          }, {
+            code: 'standby_on',
+            value: standbyOn,
+          }]
+        }
+
+        for (const command of commands) {
+          await this.sendCommand(command).catch((err) => {
+            if (err.tuyaCode === 2008) {
+              unsupportedSettings.push(command.code);
+            } else if (err.tuyaCode === 501) {
+              unsupportedValues.push(command.code);
+            } else {
+              throw err;
+            }
+          });
+        }
+      } else {
+        await this.sendCommand({
+          code: changedKey,
+          value: newValue,
+        }).catch((err) => {
+          if (err.tuyaCode === 2008) {
+            unsupportedSettings.push(changedKey);
+          } else if (err.tuyaCode === 501) {
+            unsupportedValues.push(changedKey);
+          } else {
+            throw err;
+          }
+        });
+      }
+    }
+
+    // Report back which capabilities and values are unsupported,
+    // since we cannot programmatically remove settings.
+    const messages = [];
+
+    if (unsupportedSettings.length > 0) {
+      let unsupportedSettingsMessage =
+        this.homey.__("settings_unsupported") + " ";
+      const mappedSettingNames = unsupportedSettings.map(
+        (settingKey) => LIGHT_SETTING_LABELS[settingKey],
+      );
+      unsupportedSettingsMessage += mappedSettingNames.join(", ");
+      messages.push(unsupportedSettingsMessage);
+    }
+    if (unsupportedValues.length > 0) {
+      let unsupportedValuesMessage =
+        this.homey.__("setting_values_unsupported") + " ";
+      const mappedSettingNames = unsupportedValues.map(
+        (settingKey) => LIGHT_SETTING_LABELS[settingKey],
+      );
+      unsupportedValuesMessage += mappedSettingNames.join(", ");
+      messages.push(unsupportedValuesMessage);
+    }
+    if (messages.length > 0) {
+      return messages.join("\n");
+    }
+  }
 }
 
 module.exports = TuyaOAuth2DeviceLight;

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -2,9 +2,8 @@
 
 const TuyaOAuth2Driver = require('./TuyaOAuth2Driver');
 const TuyaOAuth2Constants = require('./TuyaOAuth2Constants');
-
-// From (0,100) in Homey to (0,1000) in Tuya
-const TUYA_PERCENTAGE_SCALING = 10;
+const {TUYA_PERCENTAGE_SCALING} = require('./TuyaOAuth2Constants');
+const {PIR_CAPABILITIES} = require('./TuyaLightConstants')
 
 /**
  * @extends TuyaOAuth2Driver
@@ -23,28 +22,6 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     TuyaOAuth2Constants.DEVICE_CATEGORIES.LIGHTING.SOLAR_LIGHT,
     // TODO
   ];
-
-  static PIR_CAPABILITIES = {
-    read_write: [],
-    read_only: ['pir_state'],
-    setting: [
-      'switch_pir', // Turn motion detection on/off
-      'pir_delay', // change motion detection duration
-      'pir_sensitivity', // Change motion detection level
-      'cds', // Change luminance detection level
-      'standby_time', // Change standby duration
-    ],
-  }
-
-  static LIGHT_SETTING_LABELS = {
-    switch_pir: "Motion Detection",
-    pir_sensitivity: "Motion Sensitivity",
-    pir_delay: "Motion Delay",
-    cds: "Luminance Detection",
-    standby_on: "Standby Light",
-    standby_time: "Standby Time",
-    standby_bright: "Standby Brightness",
-  }
 
   async onInit() {
     await super.onInit();
@@ -158,7 +135,7 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
         props.capabilities.push('alarm_motion')
       }
 
-      if (TuyaOAuth2DriverLight.PIR_CAPABILITIES.setting.includes(tuyaCapability)) {
+      if (PIR_CAPABILITIES.setting.includes(tuyaCapability)) {
         props.store.tuya_capabilities.push(tuyaCapability);
       }
 

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -64,84 +64,63 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
   onTuyaPairListDeviceProperties(device, specifications) {
     const props = super.onTuyaPairListDeviceProperties(device);
 
-    // onoff
-    const hasSwitchLed = device.status.some(({ code }) => code === 'switch_led');
-    if (hasSwitchLed) {
-      props.store.tuya_capabilities.push('switch_led');
-      props.capabilities.push('onoff');
-    }
-
-    // dim
-    const hasBrightValue = device.status.some(({ code }) => code === 'bright_value');
-    if (hasBrightValue) {
-      props.store.tuya_capabilities.push('bright_value');
-    }
-
-    const hasBrightValueV2 = device.status.some(({ code }) => code === 'bright_value_v2');
-    if (hasBrightValueV2) {
-      props.store.tuya_capabilities.push('bright_value_v2');
-    }
-
-    // light_temperature
-    const hasTemperatureValue = device.status.some(({ code }) => code === 'temp_value');
-    if (hasTemperatureValue) {
-      props.store.tuya_capabilities.push('temp_value');
-    }
-
-    const hasTemperatureValueV2 = device.status.some(({ code }) => code === 'temp_value_v2');
-    if (hasTemperatureValueV2) {
-      props.store.tuya_capabilities.push('temp_value_v2');
-    }
-
-    // light_hue + light_saturation
-    const hasColourData = device.status.some(({ code }) => code === 'colour_data');
-    if (hasColourData) {
-      props.store.tuya_capabilities.push('colour_data');
-      props.capabilities.push('light_hue');
-      props.capabilities.push('light_saturation');
-    }
-
-    const hasColourDataV2 = device.status.some(({ code }) => code === 'colour_data_v2');
-    if (hasColourDataV2) {
-      props.store.tuya_capabilities.push('colour_data_v2');
-      props.capabilities.push('light_hue');
-      props.capabilities.push('light_saturation');
-    }
-
-    if (hasTemperatureValue || hasTemperatureValueV2) {
-      props.capabilities.push('light_temperature');
-    }
-
-    if (hasBrightValue || hasBrightValueV2  || hasColourData || hasColourDataV2) {
-      props.capabilities.push('dim');
-    }
-
-    // light_mode
-    const hasWorkMode = device.status.some(({ code }) => code === 'work_mode');
-    if (hasWorkMode) {
-      props.store.tuya_capabilities.push('work_mode');
-
-      // Only add light mode capability when both temperature and colour data is available
-      if ((hasTemperatureValue || hasTemperatureValueV2) && (hasColourData || hasColourDataV2)) {
-        props.capabilities.push('light_mode');
-      }
-    }
-
     for (const status of device.status) {
       const tuyaCapability = status.code;
 
+      // onoff
+      if (tuyaCapability === 'switch_led') {
+        props.store.tuya_capabilities.push(tuyaCapability);
+        props.capabilities.push('onoff');
+      }
+
+      // dim
+      if (tuyaCapability === 'bright_value' || tuyaCapability === 'bright_value_v2') {
+        props.store.tuya_capabilities.push(tuyaCapability);
+        props.capabilities.push('dim');
+      }
+
+      // light temperature
+      if (tuyaCapability === 'temp_value' || tuyaCapability === 'temp_value_v2') {
+        props.store.tuya_capabilities.push(tuyaCapability);
+        props.capabilities.push('light_temperature');
+      }
+
+      // light hue and saturation
+      if (tuyaCapability === 'colour_data' || tuyaCapability === 'colour_data_v2') {
+        props.store.tuya_capabilities.push(tuyaCapability);
+        props.capabilities.push('light_hue');
+        props.capabilities.push('light_saturation');
+        props.capabilities.push('dim');
+      }
+
+      // light_mode
+      if (tuyaCapability === 'work_mode') {
+        props.store.tuya_capabilities.push(tuyaCapability);
+      }
+
+      // motion alarm
       if (tuyaCapability === 'pir_state') {
         props.store.tuya_capabilities.push(tuyaCapability);
         props.capabilities.push('alarm_motion')
       }
 
+      // motion alarm settings
       if (PIR_CAPABILITIES.setting.includes(tuyaCapability)) {
         props.store.tuya_capabilities.push(tuyaCapability);
       }
 
+      // standby settings
       if (tuyaCapability === 'standby_on' || tuyaCapability === 'standby_bright') { // Turn standby light on/off // Change standby brightness
         props.store.tuya_capabilities.push(tuyaCapability);
       }
+    }
+
+    // Remove duplicate capabilities
+    props.capabilities = [...new Set(props.capabilities)];
+
+    // Only add light mode capability when both temperature and colour data is available
+    if (props.capabilities.includes('light_temperature') && props.capabilities.includes('light_hue')) {
+      props.capabilities.push('light_mode');
     }
 
     // Category Specifications

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -135,7 +135,7 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
       props.capabilities.push('light_temperature');
     }
 
-    if (hasBrightValue || hasBrightValueV2) {
+    if (hasBrightValue || hasBrightValueV2  || hasColourData || hasColourDataV2) {
       props.capabilities.push('dim');
     }
 

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -84,6 +84,35 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     }
 
     // Specifications
+    // Category Specifications
+    // The main light category has both (0,255) and (0,1000) for backwards compatibility
+    // Other categories use only (0,1000)
+    if (specifications.category === "dj") {
+      props.store.tuya_brightness = { min: 25, max: 255, scale: 0, step: 1}
+      props.store.tuya_temperature = { min: 0, max: 255, scale: 0, step: 1}
+      props.store.tuya_colour = {
+        h:{min: 0, max: 360, scale: 0, step: 1},
+        s:{min: 0, max: 255, scale: 0, step: 1},
+        v:{min: 0, max: 255, scale: 0, step: 1},
+      }
+      props.store.tuya_brightness_v2 = { min: 10, max: 1000, scale: 0, step: 1}
+      props.store.tuya_temperature_v2 = {min: 0, max: 1000, scale: 0, step: 1}
+      props.store.tuya_colour_v2 = {
+        h:{min: 0, max: 360, scale: 0, step: 1},
+        s:{min: 0, max: 1000, scale: 0, step: 1},
+        v:{min: 0, max: 1000, scale: 0, step: 1},
+      }
+    } else {
+      props.store.tuya_brightness = {min: 10, max: 1000, scale: 0, step: 1}
+      props.store.tuya_temperature = {min: 0, max: 1000, scale: 0, step: 1}
+      props.store.tuya_colour = {
+        h:{min: 0, max: 360, scale: 0, step: 1},
+        s:{min: 0, max: 1000, scale: 0, step: 1},
+        v:{min: 0, max: 1000, scale: 0, step: 1},
+      }
+    }
+
+    // Device Specifications
     for (const functionSpecification of specifications.functions) {
       const tuyaCapability = functionSpecification.code;
       const values = JSON.parse(functionSpecification.values);

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -98,26 +98,22 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     const hasBrightValue = device.status.some(({ code }) => code === 'bright_value');
     if (hasBrightValue) {
       props.store.tuya_capabilities.push('bright_value');
-      props.capabilities.push('dim');
     }
 
     const hasBrightValueV2 = device.status.some(({ code }) => code === 'bright_value_v2');
     if (hasBrightValueV2) {
       props.store.tuya_capabilities.push('bright_value_v2');
-      props.capabilities.push('dim');
     }
 
     // light_temperature
     const hasTemperatureValue = device.status.some(({ code }) => code === 'temp_value');
     if (hasTemperatureValue) {
       props.store.tuya_capabilities.push('temp_value');
-      props.capabilities.push('light_temperature');
     }
 
     const hasTemperatureValueV2 = device.status.some(({ code }) => code === 'temp_value_v2');
     if (hasTemperatureValueV2) {
       props.store.tuya_capabilities.push('temp_value_v2');
-      props.capabilities.push('light_temperature');
     }
 
     // light_hue + light_saturation
@@ -133,6 +129,14 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
       props.store.tuya_capabilities.push('colour_data_v2');
       props.capabilities.push('light_hue');
       props.capabilities.push('light_saturation');
+    }
+
+    if (hasTemperatureValue || hasTemperatureValueV2) {
+      props.capabilities.push('light_temperature');
+    }
+
+    if (hasBrightValue || hasBrightValueV2) {
+      props.capabilities.push('dim');
     }
 
     // light_mode

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -3,6 +3,9 @@
 const TuyaOAuth2Driver = require('./TuyaOAuth2Driver');
 const TuyaOAuth2Constants = require('./TuyaOAuth2Constants');
 
+// From (0,100) in Homey to (0,1000) in Tuya
+const TUYA_PERCENTAGE_SCALING = 10;
+
 /**
  * @extends TuyaOAuth2Driver
  * @hideconstructor
@@ -41,6 +44,44 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     standby_on: "Standby Light",
     standby_time: "Standby Time",
     standby_bright: "Standby Brightness",
+  }
+
+  async onInit() {
+    await super.onInit();
+
+    this.homey.flow.getActionCard('light_switch_pir').registerRunListener(async (args, state) => {
+      await args.device.sendSettingCommand({
+        code: 'switch_pir',
+        value: args.value,
+      })
+    })
+
+    this.homey.flow.getActionCard('light_standby_on').registerRunListener(async (args, state) => {
+      const device = args.device;
+      const hasStandbyOn = device.store.tuya_capabilities.includes('standby_on');
+      const standbyOn = args.value;
+      const standbyBrightness = device.getSetting('standby_bright');
+      let commands;
+
+      if (!hasStandbyOn) {
+        commands = [{
+          code: 'standby_bright',
+          value: standbyOn ? standbyBrightness * TUYA_PERCENTAGE_SCALING : 0,
+        }]
+      } else {
+        commands = [{
+          code: 'standby_bright',
+          value: standbyBrightness * TUYA_PERCENTAGE_SCALING,
+        }, {
+          code: 'standby_on',
+          value: standbyOn,
+        }]
+      }
+
+      for (const command of commands) {
+        await args.device.sendSettingCommand(command)
+      }
+    })
   }
 
   onTuyaPairListDeviceProperties(device, specifications) {

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -21,6 +21,28 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     // TODO
   ];
 
+  static PIR_CAPABILITIES = {
+    read_write: [],
+    read_only: ['pir_state'],
+    setting: [
+      'switch_pir', // Turn motion detection on/off
+      'pir_delay', // change motion detection duration
+      'pir_sensitivity', // Change motion detection level
+      'cds', // Change luminance detection level
+      'standby_time', // Change standby duration
+    ],
+  }
+
+  static LIGHT_SETTING_LABELS = {
+    switch_pir: "Motion Detection",
+    pir_sensitivity: "Motion Sensitivity",
+    pir_delay: "Motion Delay",
+    cds: "Luminance Detection",
+    standby_on: "Standby Light",
+    standby_time: "Standby Time",
+    standby_bright: "Standby Brightness",
+  }
+
   onTuyaPairListDeviceProperties(device, specifications) {
     const props = super.onTuyaPairListDeviceProperties(device);
 
@@ -83,7 +105,23 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
       }
     }
 
-    // Specifications
+    for (const status of device.status) {
+      const tuyaCapability = status.code;
+
+      if (tuyaCapability === 'pir_state') {
+        props.store.tuya_capabilities.push(tuyaCapability);
+        props.capabilities.push('alarm_motion')
+      }
+
+      if (TuyaOAuth2DriverLight.PIR_CAPABILITIES.setting.includes(tuyaCapability)) {
+        props.store.tuya_capabilities.push(tuyaCapability);
+      }
+
+      if (tuyaCapability === 'standby_on' || tuyaCapability === 'standby_bright') { // Turn standby light on/off // Change standby brightness
+        props.store.tuya_capabilities.push(tuyaCapability);
+      }
+    }
+
     // Category Specifications
     // The main light category has both (0,255) and (0,1000) for backwards compatibility
     // Other categories use only (0,1000)

--- a/locales/en.json
+++ b/locales/en.json
@@ -7,5 +7,7 @@
     }
   },
   "device_offline": "The device seems to be offline. Is it powered on, and connected to the internet?",
-  "switch": "Switch __number__"
+  "switch": "Switch __number__",
+  "settings_unsupported": "Some of the changed settings are not supported by the device:",
+  "setting_values_unsupported": "Some of the changed values are not supported by the device:"
 }

--- a/locales/en.json
+++ b/locales/en.json
@@ -9,5 +9,7 @@
   "device_offline": "The device seems to be offline. Is it powered on, and connected to the internet?",
   "switch": "Switch __number__",
   "settings_unsupported": "Some of the changed settings are not supported by the device:",
-  "setting_values_unsupported": "Some of the changed values are not supported by the device:"
+  "setting_values_unsupported": "Some of the changed values are not supported by the device:",
+  "setting_unsupported": "__label__ is not supported by the device",
+  "setting_value_unsupported": "Value is not supported for __label__ by the device"
 }


### PR DESCRIPTION
**- Added support for motion lights**
The following capabilities were implemented and tested:
motion_alarm (pir_state)

The following settings were implemented and tested:
Motion Detection (switch_pir)
Motion Sensitivity (pir_sensitivity)
Motion Delay (pir_delay)
Luminance Detection: (cds)
Standby Light (standby_on)
Standby Time (standby_time)
Standby Brightness (standby_bright)

The test device did not have "standby_on", but emulated it by setting standby_bright to 0.
This is mimicked by the "Standby Light" setting when "standby_on" is not present.

**- Fixed light data ranges**
Some devices do not report their ranges. Since all categories, except for "dj", use the same values,
defaults were added based on the Tuya documentation.

**- Fixed dim implementation**
Lights that do not support either color or temperature were expected to only use "bright_value_v2" for dimming.
Now both "bright_value" and "bright_value_v2" are supported, depending on what the device reports.

**- Fixed missing dim support**
Lights that only have color control did not get the dim functionality.
