### PR TITLE
Improve unknown device functionality

### DIFF
--- a/.homeycompose/flow/actions/send_command_boolean.json
+++ b/.homeycompose/flow/actions/send_command_boolean.json
@@ -13,7 +13,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+        "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
       },
       "title": {
         "en": "Device"

--- a/.homeycompose/flow/actions/send_command_json.json
+++ b/.homeycompose/flow/actions/send_command_json.json
@@ -13,7 +13,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+        "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
       },
       "title": {
         "en": "Device"

--- a/.homeycompose/flow/actions/send_command_number.json
+++ b/.homeycompose/flow/actions/send_command_number.json
@@ -13,7 +13,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+        "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
       },
       "title": {
         "en": "Device"

--- a/.homeycompose/flow/actions/send_command_string.json
+++ b/.homeycompose/flow/actions/send_command_string.json
@@ -13,7 +13,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+        "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
       },
       "title": {
         "en": "Device"

--- a/.homeycompose/flow/triggers/receive_status_boolean.json
+++ b/.homeycompose/flow/triggers/receive_status_boolean.json
@@ -13,7 +13,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+        "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
       },
       "title": {
         "en": "Device"

--- a/.homeycompose/flow/triggers/receive_status_boolean.json
+++ b/.homeycompose/flow/triggers/receive_status_boolean.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "en": "Receive a Tuya Status (Boolean)"
+  },
+  "titleFormatted": {
+    "en": "Status [[code]] gets a new Boolean value"
+  },
+  "hint": {
+    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+  },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": {
+        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+      },
+      "title": {
+        "en": "Device"
+      }
+    },
+    {
+      "name": "code",
+      "type": "autocomplete",
+      "title": {
+        "en": "Code"
+      }
+    }
+  ],
+  "tokens": [
+    {
+      "name": "value",
+      "type": "boolean",
+      "title": { "en": "Value" },
+      "example": true
+    }
+  ]
+}

--- a/.homeycompose/flow/triggers/receive_status_json.json
+++ b/.homeycompose/flow/triggers/receive_status_json.json
@@ -13,7 +13,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+        "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
       },
       "title": {
         "en": "Device"

--- a/.homeycompose/flow/triggers/receive_status_json.json
+++ b/.homeycompose/flow/triggers/receive_status_json.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "en": "Receive a Tuya Status (JSON)"
+  },
+  "titleFormatted": {
+    "en": "Status [[code]] gets a new JSON value"
+  },
+  "hint": {
+    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+  },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": {
+        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+      },
+      "title": {
+        "en": "Device"
+      }
+    },
+    {
+      "name": "code",
+      "type": "autocomplete",
+      "title": {
+        "en": "Code"
+      }
+    }
+  ],
+  "tokens": [
+    {
+      "name": "value",
+      "type": "string",
+      "title": { "en": "Value" },
+      "example": "[{\"enabled\": true}]"
+    }
+  ]
+}

--- a/.homeycompose/flow/triggers/receive_status_number.json
+++ b/.homeycompose/flow/triggers/receive_status_number.json
@@ -13,7 +13,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+        "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
       },
       "title": {
         "en": "Device"

--- a/.homeycompose/flow/triggers/receive_status_number.json
+++ b/.homeycompose/flow/triggers/receive_status_number.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "en": "Receive a Tuya Status (Number)"
+  },
+  "titleFormatted": {
+    "en": "Status [[code]] gets a new Number value"
+  },
+  "hint": {
+    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+  },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": {
+        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+      },
+      "title": {
+        "en": "Device"
+      }
+    },
+    {
+      "name": "code",
+      "type": "autocomplete",
+      "title": {
+        "en": "Code"
+      }
+    }
+  ],
+  "tokens": [
+    {
+      "name": "value",
+      "type": "number",
+      "title": { "en": "Value" },
+      "example": 5.6
+    }
+  ]
+}

--- a/.homeycompose/flow/triggers/receive_status_string.json
+++ b/.homeycompose/flow/triggers/receive_status_string.json
@@ -13,7 +13,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+        "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
       },
       "title": {
         "en": "Device"

--- a/.homeycompose/flow/triggers/receive_status_string.json
+++ b/.homeycompose/flow/triggers/receive_status_string.json
@@ -1,0 +1,38 @@
+{
+  "title": {
+    "en": "Receive a Tuya Status (String)"
+  },
+  "titleFormatted": {
+    "en": "Status [[code]] gets a new String value"
+  },
+  "hint": {
+    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+  },
+  "args": [
+    {
+      "name": "device",
+      "type": "device",
+      "filter": {
+        "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+      },
+      "title": {
+        "en": "Device"
+      }
+    },
+    {
+      "name": "code",
+      "type": "autocomplete",
+      "title": {
+        "en": "Code"
+      }
+    }
+  ],
+  "tokens": [
+    {
+      "name": "value",
+      "type": "string",
+      "title": { "en": "Value" },
+      "example": "color"
+    }
+  ]
+}

--- a/app.json
+++ b/app.json
@@ -301,6 +301,245 @@
   "support": "https://homey.app/support",
   "source": "https://github.com/athombv/com.tuya",
   "flow": {
+    "triggers": [
+      {
+        "title": {
+          "en": "Receive a Tuya Status (Boolean)"
+        },
+        "titleFormatted": {
+          "en": "Status [[code]] gets a new Boolean value"
+        },
+        "hint": {
+          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": {
+              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+            },
+            "title": {
+              "en": "Device"
+            }
+          },
+          {
+            "name": "code",
+            "type": "autocomplete",
+            "title": {
+              "en": "Code"
+            }
+          }
+        ],
+        "tokens": [
+          {
+            "name": "value",
+            "type": "boolean",
+            "title": {
+              "en": "Value"
+            },
+            "example": true
+          }
+        ],
+        "id": "receive_status_boolean"
+      },
+      {
+        "title": {
+          "en": "Receive a Tuya Status (JSON)"
+        },
+        "titleFormatted": {
+          "en": "Status [[code]] gets a new JSON value"
+        },
+        "hint": {
+          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": {
+              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+            },
+            "title": {
+              "en": "Device"
+            }
+          },
+          {
+            "name": "code",
+            "type": "autocomplete",
+            "title": {
+              "en": "Code"
+            }
+          }
+        ],
+        "tokens": [
+          {
+            "name": "value",
+            "type": "string",
+            "title": {
+              "en": "Value"
+            },
+            "example": "[{\"enabled\": true}]"
+          }
+        ],
+        "id": "receive_status_json"
+      },
+      {
+        "title": {
+          "en": "Receive a Tuya Status (Number)"
+        },
+        "titleFormatted": {
+          "en": "Status [[code]] gets a new Number value"
+        },
+        "hint": {
+          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": {
+              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+            },
+            "title": {
+              "en": "Device"
+            }
+          },
+          {
+            "name": "code",
+            "type": "autocomplete",
+            "title": {
+              "en": "Code"
+            }
+          }
+        ],
+        "tokens": [
+          {
+            "name": "value",
+            "type": "number",
+            "title": {
+              "en": "Value"
+            },
+            "example": 5.6
+          }
+        ],
+        "id": "receive_status_number"
+      },
+      {
+        "title": {
+          "en": "Receive a Tuya Status (String)"
+        },
+        "titleFormatted": {
+          "en": "Status [[code]] gets a new String value"
+        },
+        "hint": {
+          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+        },
+        "args": [
+          {
+            "name": "device",
+            "type": "device",
+            "filter": {
+              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+            },
+            "title": {
+              "en": "Device"
+            }
+          },
+          {
+            "name": "code",
+            "type": "autocomplete",
+            "title": {
+              "en": "Code"
+            }
+          }
+        ],
+        "tokens": [
+          {
+            "name": "value",
+            "type": "string",
+            "title": {
+              "en": "Value"
+            },
+            "example": "color"
+          }
+        ],
+        "id": "receive_status_string"
+      },
+      {
+        "id": "doorbell_rang",
+        "title": {
+          "en": "The doorbell rang"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=doorbell"
+          }
+        ]
+      },
+      {
+        "id": "socket_sub_switch_turned_off",
+        "highlight": true,
+        "title": {
+          "en": "Turned switch off"
+        },
+        "titleFormatted": {
+          "en": "Turned [[switch]] off"
+        },
+        "hint": {
+          "en": "A specific switch on the device turned off."
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=socket&capabilities=onoff.switch_1|onoff.switch_2|onoff.switch_3|onoff.switch_4|onoff.switch_5|onoff.switch_6"
+          },
+          {
+            "name": "switch",
+            "type": "autocomplete",
+            "title": {
+              "en": "Switch"
+            },
+            "placeholder": {
+              "en": "Switch 1"
+            }
+          }
+        ]
+      },
+      {
+        "id": "socket_sub_switch_turned_on",
+        "highlight": true,
+        "title": {
+          "en": "Turned switch on"
+        },
+        "titleFormatted": {
+          "en": "Turned [[switch]] on"
+        },
+        "hint": {
+          "en": "A specific switch on the device turned on."
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=socket&capabilities=onoff.switch_1|onoff.switch_2|onoff.switch_3|onoff.switch_4|onoff.switch_5|onoff.switch_6"
+          },
+          {
+            "name": "switch",
+            "type": "autocomplete",
+            "title": {
+              "en": "Switch"
+            },
+            "placeholder": {
+              "en": "Switch 1"
+            }
+          }
+        ]
+      }
+    ],
     "actions": [
       {
         "title": {
@@ -495,81 +734,6 @@
         },
         "hint": {
           "en": "Turn only a specific switch on the device on."
-        },
-        "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=socket&capabilities=onoff.switch_1|onoff.switch_2|onoff.switch_3|onoff.switch_4|onoff.switch_5|onoff.switch_6"
-          },
-          {
-            "name": "switch",
-            "type": "autocomplete",
-            "title": {
-              "en": "Switch"
-            },
-            "placeholder": {
-              "en": "Switch 1"
-            }
-          }
-        ]
-      }
-    ],
-    "triggers": [
-      {
-        "id": "doorbell_rang",
-        "title": {
-          "en": "The doorbell rang"
-        },
-        "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=doorbell"
-          }
-        ]
-      },
-      {
-        "id": "socket_sub_switch_turned_off",
-        "highlight": true,
-        "title": {
-          "en": "Turned switch off"
-        },
-        "titleFormatted": {
-          "en": "Turned [[switch]] off"
-        },
-        "hint": {
-          "en": "A specific switch on the device turned off."
-        },
-        "args": [
-          {
-            "type": "device",
-            "name": "device",
-            "filter": "driver_id=socket&capabilities=onoff.switch_1|onoff.switch_2|onoff.switch_3|onoff.switch_4|onoff.switch_5|onoff.switch_6"
-          },
-          {
-            "name": "switch",
-            "type": "autocomplete",
-            "title": {
-              "en": "Switch"
-            },
-            "placeholder": {
-              "en": "Switch 1"
-            }
-          }
-        ]
-      },
-      {
-        "id": "socket_sub_switch_turned_on",
-        "highlight": true,
-        "title": {
-          "en": "Turned switch on"
-        },
-        "titleFormatted": {
-          "en": "Turned [[switch]] on"
-        },
-        "hint": {
-          "en": "A specific switch on the device turned on."
         },
         "args": [
           {

--- a/app.json
+++ b/app.json
@@ -317,7 +317,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+              "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
             },
             "title": {
               "en": "Device"
@@ -358,7 +358,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+              "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
             },
             "title": {
               "en": "Device"
@@ -399,7 +399,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+              "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
             },
             "title": {
               "en": "Device"
@@ -440,7 +440,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+              "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
             },
             "title": {
               "en": "Device"
@@ -556,7 +556,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+              "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
             },
             "title": {
               "en": "Device"
@@ -594,7 +594,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+              "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
             },
             "title": {
               "en": "Device"
@@ -632,7 +632,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+              "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
             },
             "title": {
               "en": "Device"
@@ -670,7 +670,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
+              "driver_id": "doorbell|fan|light|other|sensor_contact|sensor_motion|sensor_smoke|socket"
             },
             "title": {
               "en": "Device"

--- a/drivers/other/device.js
+++ b/drivers/other/device.js
@@ -1,12 +1,5 @@
-'use strict';
+"use strict";
 
-const TuyaOAuth2Device = require('../../lib/TuyaOAuth2Device');
+const TuyaOAuth2Device = require("../../lib/TuyaOAuth2Device");
 
-module.exports = class TuyaOAuth2DeviceOther extends TuyaOAuth2Device {
-
-  async onOAuth2Init() {
-    // Do nothing here. We don't want an 'other' device to subscribe to webhook events.
-    // If a user has the same physical device also paired, e.g. a light bulb, that device might not receive the events.
-  }
-
-};
+module.exports = class TuyaOAuth2DeviceOther extends TuyaOAuth2Device {};

--- a/lib/TuyaOAuth2App.js
+++ b/lib/TuyaOAuth2App.js
@@ -1,19 +1,19 @@
-"use strict";
+'use strict';
 
-const { OAuth2App } = require("homey-oauth2app");
-const TuyaOAuth2Client = require("./TuyaOAuth2Client");
-const TuyaOAuth2Util = require("./TuyaOAuth2Util");
+const { OAuth2App } = require('homey-oauth2app');
+const TuyaOAuth2Client = require('./TuyaOAuth2Client');
+const TuyaOAuth2Util = require('./TuyaOAuth2Util');
 
 class TuyaOAuth2App extends OAuth2App {
   static OAUTH2_CLIENT = TuyaOAuth2Client;
-  static OAUTH2_DEBUG = process.env.DEBUG === "1";
+  static OAUTH2_DEBUG = process.env.DEBUG === '1';
   static OAUTH2_MULTI_SESSION = false; // TODO: Enable this feature & make nice pairing UI
 
   async onOAuth2Init() {
     await super.onOAuth2Init();
 
     const sendCommandRunListener = async ({ device, code, value }) => {
-      if (typeof code === "object") code = code.id;
+      if (typeof code === 'object') code = code.id;
       await device.sendCommand({ code, value });
     };
 
@@ -33,91 +33,67 @@ class TuyaOAuth2App extends OAuth2App {
     // Register Tuya Web API Flow Cards
     // Sending
     this.homey.flow
-      .getActionCard("send_command_string")
+      .getActionCard('send_command_string')
       .registerRunListener(async (args) => sendCommandRunListener(args))
-      .registerArgumentAutocompleteListener("code", async (query, args) =>
-        generalControlAutocompleteListener(query, args, ({ value }) => {
-          return (
-            typeof value === "string" && !TuyaOAuth2Util.hasJsonStructure(value)
-          );
-        }),
+      .registerArgumentAutocompleteListener('code', async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'string' && !TuyaOAuth2Util.hasJsonStructure(value)),
       );
 
     this.homey.flow
-      .getActionCard("send_command_number")
+      .getActionCard('send_command_number')
       .registerRunListener(async (args) => sendCommandRunListener(args))
-      .registerArgumentAutocompleteListener("code", async (query, args) =>
-        generalControlAutocompleteListener(query, args, ({ value }) => {
-          return typeof value === "number";
-        }),
+      .registerArgumentAutocompleteListener('code', async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'number'),
       );
 
     this.homey.flow
-      .getActionCard("send_command_boolean")
+      .getActionCard('send_command_boolean')
       .registerRunListener(async (args) => sendCommandRunListener(args))
-      .registerArgumentAutocompleteListener("code", async (query, args) =>
-        generalControlAutocompleteListener(query, args, ({ value }) => {
-          return typeof value === "boolean";
-        }),
+      .registerArgumentAutocompleteListener('code', async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'boolean'),
       );
 
     this.homey.flow
-      .getActionCard("send_command_json")
+      .getActionCard('send_command_json')
       .registerRunListener(async ({ device, code, value }) => {
-        if (typeof code === "object") code = code.id;
+        if (typeof code === 'object') code = code.id;
 
         await device.sendCommand({
           code,
           value: JSON.parse(value),
         });
       })
-      .registerArgumentAutocompleteListener("code", async (query, args) =>
-        generalControlAutocompleteListener(query, args, ({ value }) => {
-          return (
-            typeof value === "object" || TuyaOAuth2Util.hasJsonStructure(value)
-          );
-        }),
+      .registerArgumentAutocompleteListener('code', async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'object' || TuyaOAuth2Util.hasJsonStructure(value)),
       );
 
     // Receiving
     this.homey.flow
-      .getDeviceTriggerCard("receive_status_boolean")
+      .getDeviceTriggerCard('receive_status_boolean')
       .registerRunListener((args, state) => args.code.id === state.code)
-      .registerArgumentAutocompleteListener("code", async (query, args) =>
-        generalControlAutocompleteListener(query, args, ({ value }) => {
-          return typeof value === "boolean";
-        }),
+      .registerArgumentAutocompleteListener('code', async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'boolean'),
       );
 
     this.homey.flow
-      .getDeviceTriggerCard("receive_status_json")
+      .getDeviceTriggerCard('receive_status_json')
       .registerRunListener((args, state) => args.code.id === state.code)
-      .registerArgumentAutocompleteListener("code", async (query, args) =>
-        generalControlAutocompleteListener(query, args, ({ value }) => {
-          return (
-            typeof value === "object" || TuyaOAuth2Util.hasJsonStructure(value)
-          );
-        }),
+      .registerArgumentAutocompleteListener('code', async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'object' || TuyaOAuth2Util.hasJsonStructure(value)),
       );
 
     this.homey.flow
-      .getDeviceTriggerCard("receive_status_number")
+      .getDeviceTriggerCard('receive_status_number')
       .registerRunListener((args, state) => args.code.id === state.code)
-      .registerArgumentAutocompleteListener("code", async (query, args) =>
-        generalControlAutocompleteListener(query, args, ({ value }) => {
-          return typeof value === "number";
-        }),
+      .registerArgumentAutocompleteListener('code', async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'number'),
       );
 
     this.homey.flow
-      .getDeviceTriggerCard("receive_status_string")
+      .getDeviceTriggerCard('receive_status_string')
       .registerRunListener((args, state) => args.code.id === state.code)
-      .registerArgumentAutocompleteListener("code", async (query, args) =>
-        generalControlAutocompleteListener(query, args, ({ value }) => {
-          return (
-            typeof value === "string" && !TuyaOAuth2Util.hasJsonStructure(value)
-          );
-        }),
+      .registerArgumentAutocompleteListener('code', async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'string' && !TuyaOAuth2Util.hasJsonStructure(value)),
       );
   }
 }

--- a/lib/TuyaOAuth2App.js
+++ b/lib/TuyaOAuth2App.js
@@ -34,21 +34,21 @@ class TuyaOAuth2App extends OAuth2App {
     // Sending
     this.homey.flow
       .getActionCard('send_command_string')
-      .registerRunListener(async (args) => sendCommandRunListener(args))
+      .registerRunListener(sendCommandRunListener)
       .registerArgumentAutocompleteListener('code', async (query, args) =>
         generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'string' && !TuyaOAuth2Util.hasJsonStructure(value)),
       );
 
     this.homey.flow
       .getActionCard('send_command_number')
-      .registerRunListener(async (args) => sendCommandRunListener(args))
+      .registerRunListener(sendCommandRunListener)
       .registerArgumentAutocompleteListener('code', async (query, args) =>
         generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'number'),
       );
 
     this.homey.flow
       .getActionCard('send_command_boolean')
-      .registerRunListener(async (args) => sendCommandRunListener(args))
+      .registerRunListener(sendCommandRunListener)
       .registerArgumentAutocompleteListener('code', async (query, args) =>
         generalControlAutocompleteListener(query, args, ({ value }) => typeof value === 'boolean'),
       );

--- a/lib/TuyaOAuth2App.js
+++ b/lib/TuyaOAuth2App.js
@@ -1,110 +1,121 @@
-'use strict';
+"use strict";
 
-const { OAuth2App } = require('homey-oauth2app');
-const TuyaOAuth2Client = require('./TuyaOAuth2Client');
+const { OAuth2App } = require("homey-oauth2app");
+const TuyaOAuth2Client = require("./TuyaOAuth2Client");
+const TuyaOAuth2Util = require("./TuyaOAuth2Util");
 
 class TuyaOAuth2App extends OAuth2App {
-
   static OAUTH2_CLIENT = TuyaOAuth2Client;
-  static OAUTH2_DEBUG = process.env.DEBUG === '1';
+  static OAUTH2_DEBUG = process.env.DEBUG === "1";
   static OAUTH2_MULTI_SESSION = false; // TODO: Enable this feature & make nice pairing UI
 
   async onOAuth2Init() {
     await super.onOAuth2Init();
 
+    const sendCommandRunListener = async ({ device, code, value }) => {
+      if (typeof code === "object") code = code.id;
+      await device.sendCommand({ code, value });
+    };
+
+    const generalControlAutocompleteListener = async (query, args, filter) => {
+      const status = await args.device.getStatus();
+      return status
+        .filter(filter)
+        .filter(({ code }) => {
+          return code.toLowerCase().includes(query.toLowerCase());
+        })
+        .map(({ code }) => ({
+          id: code,
+          title: code,
+        }));
+    };
+
     // Register Tuya Web API Flow Cards
+    // Sending
     this.homey.flow
-      .getActionCard('send_command_string')
-      .registerRunListener(async ({ device, code, value }) => {
-        if (typeof code === 'object') code = code.id;
-
-        await device.sendCommand({ code, value });
-      })
-      .registerArgumentAutocompleteListener('code', async (query, args) => {
-        const status = await args.device.getStatus();
-        return status
-          .filter(({ value }) => {
-            return typeof value === 'string' && !value.startsWith('{');
-          })
-          .filter(({ code }) => {
-            return code.toLowerCase().includes(query.toLowerCase());
-          })
-          .map(({ code }) => ({
-            id: code,
-            title: code,
-          }));
-      });
+      .getActionCard("send_command_string")
+      .registerRunListener(async (args) => sendCommandRunListener(args))
+      .registerArgumentAutocompleteListener("code", async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => {
+          return (
+            typeof value === "string" && !TuyaOAuth2Util.hasJsonStructure(value)
+          );
+        }),
+      );
 
     this.homey.flow
-      .getActionCard('send_command_number')
-      .registerRunListener(async ({ device, code, value }) => {
-        if (typeof code === 'object') code = code.id;
-
-        await device.sendCommand({ code, value });
-      })
-      .registerArgumentAutocompleteListener('code', async (query, args) => {
-        const status = await args.device.getStatus();
-        return status
-          .filter(({ value }) => {
-            return typeof value === 'number';
-          })
-          .filter(({ code }) => {
-            return code.toLowerCase().includes(query.toLowerCase());
-          })
-          .map(({ code }) => ({
-            id: code,
-            title: code,
-          }));
-      });
+      .getActionCard("send_command_number")
+      .registerRunListener(async (args) => sendCommandRunListener(args))
+      .registerArgumentAutocompleteListener("code", async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => {
+          return typeof value === "number";
+        }),
+      );
 
     this.homey.flow
-      .getActionCard('send_command_boolean')
-      .registerRunListener(async ({ device, code, value }) => {
-        if (typeof code === 'object') code = code.id;
-
-        await device.sendCommand({ code, value });
-      })
-      .registerArgumentAutocompleteListener('code', async (query, args) => {
-        const status = await args.device.getStatus();
-        return status
-          .filter(({ value }) => {
-            return typeof value === 'boolean';
-          })
-          .filter(({ code }) => {
-            return code.toLowerCase().includes(query.toLowerCase());
-          })
-          .map(({ code }) => ({
-            id: code,
-            title: code,
-          }));
-      });
+      .getActionCard("send_command_boolean")
+      .registerRunListener(async (args) => sendCommandRunListener(args))
+      .registerArgumentAutocompleteListener("code", async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => {
+          return typeof value === "boolean";
+        }),
+      );
 
     this.homey.flow
-      .getActionCard('send_command_json')
+      .getActionCard("send_command_json")
       .registerRunListener(async ({ device, code, value }) => {
-        if (typeof code === 'object') code = code.id;
+        if (typeof code === "object") code = code.id;
 
         await device.sendCommand({
           code,
           value: JSON.parse(value),
         });
       })
-      .registerArgumentAutocompleteListener('code', async (query, args) => {
-        const status = await args.device.getStatus();
-        return status
-          .filter(({ value }) => {
-            return typeof value === 'string' && value.startsWith('{');
-          })
-          .filter(({ code }) => {
-            return code.toLowerCase().includes(query.toLowerCase());
-          })
-          .map(({ code }) => ({
-            id: code,
-            title: code,
-          }));
-      });
-  }
+      .registerArgumentAutocompleteListener("code", async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => {
+          return TuyaOAuth2Util.hasJsonStructure(value);
+        }),
+      );
 
+    // Receiving
+    this.homey.flow
+      .getDeviceTriggerCard("receive_status_boolean")
+      .registerRunListener((args, state) => args.code.id === state.code)
+      .registerArgumentAutocompleteListener("code", async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => {
+          return typeof value === "boolean";
+        }),
+      );
+
+    this.homey.flow
+      .getDeviceTriggerCard("receive_status_json")
+      .registerRunListener((args, state) => args.code.id === state.code)
+      .registerArgumentAutocompleteListener("code", async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => {
+          return TuyaOAuth2Util.hasJsonStructure(value);
+        }),
+      );
+
+    this.homey.flow
+      .getDeviceTriggerCard("receive_status_number")
+      .registerRunListener((args, state) => args.code.id === state.code)
+      .registerArgumentAutocompleteListener("code", async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => {
+          return typeof value === "number";
+        }),
+      );
+
+    this.homey.flow
+      .getDeviceTriggerCard("receive_status_string")
+      .registerRunListener((args, state) => args.code.id === state.code)
+      .registerArgumentAutocompleteListener("code", async (query, args) =>
+        generalControlAutocompleteListener(query, args, ({ value }) => {
+          return (
+            typeof value === "string" && !TuyaOAuth2Util.hasJsonStructure(value)
+          );
+        }),
+      );
+  }
 }
 
 module.exports = TuyaOAuth2App;

--- a/lib/TuyaOAuth2App.js
+++ b/lib/TuyaOAuth2App.js
@@ -73,7 +73,9 @@ class TuyaOAuth2App extends OAuth2App {
       })
       .registerArgumentAutocompleteListener("code", async (query, args) =>
         generalControlAutocompleteListener(query, args, ({ value }) => {
-          return TuyaOAuth2Util.hasJsonStructure(value);
+          return (
+            typeof value === "object" || TuyaOAuth2Util.hasJsonStructure(value)
+          );
         }),
       );
 
@@ -92,7 +94,9 @@ class TuyaOAuth2App extends OAuth2App {
       .registerRunListener((args, state) => args.code.id === state.code)
       .registerArgumentAutocompleteListener("code", async (query, args) =>
         generalControlAutocompleteListener(query, args, ({ value }) => {
-          return TuyaOAuth2Util.hasJsonStructure(value);
+          return (
+            typeof value === "object" || TuyaOAuth2Util.hasJsonStructure(value)
+          );
         }),
       );
 

--- a/lib/TuyaOAuth2Client.js
+++ b/lib/TuyaOAuth2Client.js
@@ -238,15 +238,23 @@ class TuyaOAuth2Client extends OAuth2Client {
    * Webhooks
    */
   registeredDevices = new Map();
+  // Devices that are added as 'other' may be duplicates
+  registeredOtherDevices = new Map();
 
-  async registerDevice({
-    productId,
-    deviceId,
-    onStatus = () => { },
-    onOnline = () => { },
-    onOffline = () => { },
-  }) {
-    this.registeredDevices.set(`${productId}:${deviceId}`, {
+  async registerDevice(
+    {
+      productId,
+      deviceId,
+      onStatus = () => {},
+      onOnline = () => {},
+      onOffline = () => {},
+    },
+    other = false,
+  ) {
+    const register = other
+      ? this.registeredOtherDevices
+      : this.registeredDevices;
+    register.set(`${productId}:${deviceId}`, {
       productId,
       deviceId,
       onStatus,
@@ -256,11 +264,11 @@ class TuyaOAuth2Client extends OAuth2Client {
     this.onUpdateWebhook();
   }
 
-  async unregisterDevice({
-    productId,
-    deviceId,
-  }) {
-    this.registeredDevices.delete(`${productId}:${deviceId}`);
+  async unregisterDevice({ productId, deviceId }, other = false) {
+    const register = other
+      ? this.registeredOtherDevices
+      : this.registeredDevices;
+    register.delete(`${productId}:${deviceId}`);
     this.onUpdateWebhook();
   }
 

--- a/lib/TuyaOAuth2Client.js
+++ b/lib/TuyaOAuth2Client.js
@@ -18,7 +18,7 @@ class TuyaOAuth2Client extends OAuth2Client {
   static AUTHORIZATION_URL = 'https://openapi.tuyaus.com/login';
   static REDIRECT_URL = 'https://tuya.athom.com/callback';
 
-  /* 
+  /*
    * OAuth2Client Overloads
    */
 
@@ -280,15 +280,18 @@ class TuyaOAuth2Client extends OAuth2Client {
     this.__updateWebhookTimeout = setTimeout(() => {
       Promise.resolve().then(async () => {
         const keys = Array.from(this.registeredDevices.keys());
+        const otherKeys = Array.from(this.registeredOtherDevices.keys());
+        // Remove duplicate registrations
+        const combinedKeys = Array.from(new Set([...keys, ...otherKeys]));
 
-        if (Object.keys(keys).length === 0 && this.webhook) {
+        if (combinedKeys.length === 0 && this.webhook) {
           await this.webhook.unregister();
           this.log('Unregistered Webhook');
         }
 
-        if (Object.keys(keys).length > 0) {
+        if (combinedKeys.length > 0) {
           this.webhook = await this.homey.cloud.createWebhook(Homey.env.WEBHOOK_ID, Homey.env.WEBHOOK_SECRET, {
-            $keys: keys,
+            $keys: combinedKeys,
           });
           this.webhook.on('message', message => {
             this.log('onWebhookMessage', JSON.stringify(message));
@@ -297,22 +300,38 @@ class TuyaOAuth2Client extends OAuth2Client {
               const key = message.headers['x-tuya-key'];
 
               const registeredDevice = this.registeredDevices.get(key);
-              if (!registeredDevice) return;
+              const registeredOtherDevice = this.registeredOtherDevices.get(key);
+              if (!registeredDevice && !registeredOtherDevice) return;
 
               Promise.resolve().then(async () => {
                 switch (message.body.event) {
                   case 'status': {
                     if (!Array.isArray(message.body.data.deviceStatus)) return;
 
-                    await registeredDevice.onStatus(message.body.data.deviceStatus);
+                    if (registeredDevice) {
+                      await registeredDevice.onStatus(message.body.data.deviceStatus);
+                    }
+                    if (registeredOtherDevice) {
+                      await registeredOtherDevice.onStatus(message.body.data.deviceStatus);
+                    }
                     break;
                   }
                   case 'online': {
-                    await registeredDevice.onOnline();
+                    if (registeredDevice) {
+                      await registeredDevice.onOnline();
+                    }
+                    if (registeredOtherDevice) {
+                      await registeredOtherDevice.onOnline();
+                    }
                     break;
                   }
                   case 'offline': {
-                    await registeredDevice.onOffline();
+                    if (registeredDevice) {
+                      await registeredDevice.onOffline();
+                    }
+                    if (registeredOtherDevice) {
+                      await registeredOtherDevice.onOffline();
+                    }
                     break;
                   }
                   default: {

--- a/lib/TuyaOAuth2Device.js
+++ b/lib/TuyaOAuth2Device.js
@@ -98,7 +98,7 @@ class TuyaOAuth2Device extends OAuth2Device {
     };
 
     for (const changedStatusCode of changedStatusCodes) {
-      const changedStatusValue = status[changedStatusCode];
+      let changedStatusValue = status[changedStatusCode];
 
       let triggerCardId;
 
@@ -113,6 +113,9 @@ class TuyaOAuth2Device extends OAuth2Device {
         } else {
           triggerCardId = "receive_status_string";
         }
+      } else if (typeof changedStatusValue === 'object') {
+        changedStatusValue = JSON.stringify(changedStatusValue);
+        triggerCardId = "receive_status_json";
       }
 
       await this.homey.flow.getDeviceTriggerCard(triggerCardId).trigger(this, {

--- a/lib/TuyaOAuth2Device.js
+++ b/lib/TuyaOAuth2Device.js
@@ -37,6 +37,8 @@ class TuyaOAuth2Device extends OAuth2Device {
   async onOAuth2Init() {
     await super.onOAuth2Init();
 
+    const isOtherDevice = this.driver.id === "other";
+
     this.oAuth2Client.registerDevice({
       ...this.data,
       onStatus: async statuses => {
@@ -57,7 +59,9 @@ class TuyaOAuth2Device extends OAuth2Device {
           online: false,
         });
       },
-    });
+    },
+      isOtherDevice,
+    );
 
     if (typeof this.constructor.SYNC_INTERVAL === 'number') {
       this.__syncInterval = this.homey.setInterval(this.__sync, this.constructor.SYNC_INTERVAL);
@@ -75,9 +79,12 @@ class TuyaOAuth2Device extends OAuth2Device {
     }
 
     if (this.oAuth2Client) {
-      this.oAuth2Client.unregisterDevice({
-        ...this.data,
-      });
+      const isOtherDevice = this.driver.id === "other";
+
+      this.oAuth2Client.unregisterDevice(
+        {...this.data},
+        isOtherDevice,
+      );
     }
   }
 

--- a/lib/TuyaOAuth2Device.js
+++ b/lib/TuyaOAuth2Device.js
@@ -101,7 +101,6 @@ class TuyaOAuth2Device extends OAuth2Device {
       let changedStatusValue = status[changedStatusCode];
 
       let triggerCardId;
-
       if (typeof changedStatusValue === 'boolean') {
         triggerCardId = "receive_status_boolean";
       } else if (typeof changedStatusValue === 'number') {
@@ -122,7 +121,7 @@ class TuyaOAuth2Device extends OAuth2Device {
         value: changedStatusValue,
       }, {
         code: changedStatusCode,
-      }).catch(err => this.error(err))
+      }).catch(this.error)
     }
 
     await this.onTuyaStatus(this.__status, changedStatusCodes);

--- a/lib/TuyaOAuth2Device.js
+++ b/lib/TuyaOAuth2Device.js
@@ -97,6 +97,31 @@ class TuyaOAuth2Device extends OAuth2Device {
       ...status,
     };
 
+    for (const changedStatusCode of changedStatusCodes) {
+      const changedStatusValue = status[changedStatusCode];
+
+      let triggerCardId;
+
+      if (typeof changedStatusValue === 'boolean') {
+        triggerCardId = "receive_status_boolean";
+      } else if (typeof changedStatusValue === 'number') {
+        triggerCardId = "receive_status_number";
+      } else if (typeof changedStatusValue === 'string') {
+        const hasJsonStructure = TuyaOAuth2Util.hasJsonStructure(changedStatusValue);
+        if (hasJsonStructure) {
+          triggerCardId = "receive_status_json";
+        } else {
+          triggerCardId = "receive_status_string";
+        }
+      }
+
+      await this.homey.flow.getDeviceTriggerCard(triggerCardId).trigger(this, {
+        value: changedStatusValue,
+      }, {
+        code: changedStatusCode,
+      }).catch(err => this.error(err))
+    }
+
     await this.onTuyaStatus(this.__status, changedStatusCodes);
   }
 

--- a/lib/TuyaOAuth2Util.js
+++ b/lib/TuyaOAuth2Util.js
@@ -96,6 +96,18 @@ class TuyaOAuth2Util {
     return newObj;
   }
 
+  static hasJsonStructure(str) {
+    if (typeof str !== 'string') return false;
+    try {
+      const result = JSON.parse(str);
+      const type = Object.prototype.toString.call(result);
+      return type === '[object Object]'
+        || type === '[object Array]';
+    } catch (err) {
+      return false;
+    }
+  }
+
 }
 
 module.exports = TuyaOAuth2Util;


### PR DESCRIPTION
**Added 'other' devices to webhook registration**
A separate register of 'other' devices is kept, so that devices with dedicated drivers can also be added as 'other' without breaking them.

**Added flow cards for receiving Tuya statuses**
These trigger flow cards match the existing action flows, supporting numbers, booleans, strings and JSON.
Since Tuya sometimes encodes JSON twice strings are also checked for JSON format, with the action card updated to do the same.