### PR TITLE
Fix socket for out-of-spec switch capability

### DIFF
--- a/lib/TuyaOAuth2DeviceSocket.js
+++ b/lib/TuyaOAuth2DeviceSocket.js
@@ -64,6 +64,10 @@ class TuyaOAuth2DeviceSocket extends TuyaOAuth2Device {
       }
     }
 
+    if (typeof status['switch'] === 'boolean') {
+      anySwitchOn |= status['switch'];
+    }
+
     this.safeSetCapabilityValue('onoff', anySwitchOn).catch(this.error);
 
     if (typeof status['cur_power'] === 'number') {

--- a/lib/TuyaOAuth2DeviceSocket.js
+++ b/lib/TuyaOAuth2DeviceSocket.js
@@ -65,7 +65,7 @@ class TuyaOAuth2DeviceSocket extends TuyaOAuth2Device {
     }
 
     if (typeof status['switch'] === 'boolean') {
-      anySwitchOn |= status['switch'];
+      anySwitchOn = anySwitchOn || status['switch'];
     }
 
     this.safeSetCapabilityValue('onoff', anySwitchOn).catch(this.error);

--- a/lib/TuyaOAuth2DriverSocket.js
+++ b/lib/TuyaOAuth2DriverSocket.js
@@ -73,6 +73,8 @@ class TuyaOAuth2DriverSocket extends TuyaOAuth2Driver {
         props.store.tuya_switches.push(tuyaCapability);
         props.store.tuya_capabilities.push(tuyaCapability);
 
+        props.capabilities.push(`onoff.switch`);
+
         // Break early, as having both switch and numbered switches should not occur and breaks stuff
         break;
       }

--- a/lib/TuyaOAuth2DriverSocket.js
+++ b/lib/TuyaOAuth2DriverSocket.js
@@ -66,126 +66,39 @@ class TuyaOAuth2DriverSocket extends TuyaOAuth2Driver {
     props.capabilities.push('onoff')
 
     // onoff
-    const hasSwitch1 = device.status.some(({ code }) => code === `switch_1`);
-    if (hasSwitch1) {
-      props.store.tuya_switches.push(`switch_1`);
-      props.store.tuya_capabilities.push(`switch_1`);
+    for (const status of device.status) {
+      const tuyaCapability = status.code;
 
-      props.capabilities.push(`onoff.switch_1`);
+      if (tuyaCapability === 'switch') {
+        props.store.tuya_switches.push(tuyaCapability);
+        props.store.tuya_capabilities.push(tuyaCapability);
 
-      props.capabilitiesOptions[`onoff.switch_1`] = {
-        title: {
-          en: `Switch 1`
-        },
-        insightsTitleTrue: {
-          en: `Turned on (Switch 1)`,
-        },
-        insightsTitleFalse: {
-          en: `Turned off (Switch 1)`,
-        },
-      };
+        // Break early, as having both switch and numbered switches should not occur and breaks stuff
+        break;
+      }
+
+      for (let switch_i = 1; switch_i <= 6; switch_i++) {
+        if (tuyaCapability === `switch_${switch_i}`) {
+          props.store.tuya_switches.push(tuyaCapability);
+          props.store.tuya_capabilities.push(tuyaCapability);
+
+          const homeyCapability = `onoff.switch_${switch_i}`;
+          props.capabilities.push(homeyCapability);
+
+          props.capabilitiesOptions[homeyCapability] = {
+            title: {
+              en: `Switch ${switch_i}`
+            },
+            insightsTitleTrue: {
+              en: `Turned on (Switch ${switch_i})`,
+            },
+            insightsTitleFalse: {
+              en: `Turned off (Switch ${switch_i})`,
+            },
+          };
+        }
+      }
     }
-
-    const hasSwitch2 = device.status.some(({ code }) => code === `switch_2`);
-    if (hasSwitch2) {
-      props.store.tuya_switches.push(`switch_2`);
-      props.store.tuya_capabilities.push(`switch_2`);
-
-      props.capabilities.push(`onoff.switch_2`);
-
-      props.capabilitiesOptions[`onoff.switch_2`] = {
-        title: {
-          en: `Switch 2`
-        },
-        insightsTitleTrue: {
-          en: `Turned on (Switch 2)`,
-        },
-        insightsTitleFalse: {
-          en: `Turned off (Switch 2)`,
-        },
-      };
-    }
-
-    const hasSwitch3 = device.status.some(({ code }) => code === `switch_3`);
-    if (hasSwitch3) {
-      props.store.tuya_switches.push(`switch_3`);
-      props.store.tuya_capabilities.push(`switch_3`);
-
-      props.capabilities.push(`onoff.switch_3`);
-
-      props.capabilitiesOptions[`onoff.switch_3`] = {
-        title: {
-          en: `Switch 3`
-        },
-        insightsTitleTrue: {
-          en: `Turned on (Switch 3)`,
-        },
-        insightsTitleFalse: {
-          en: `Turned off (Switch 3)`,
-        },
-      };
-    }
-
-    const hasSwitch4 = device.status.some(({ code }) => code === `switch_4`);
-    if (hasSwitch4) {
-      props.store.tuya_switches.push(`switch_4`);
-      props.store.tuya_capabilities.push(`switch_4`);
-
-      props.capabilities.push(`onoff.switch_4`);
-
-      props.capabilitiesOptions[`onoff.switch_4`] = {
-        title: {
-          en: `Switch 4`
-        },
-        insightsTitleTrue: {
-          en: `Turned on (Switch 4)`,
-        },
-        insightsTitleFalse: {
-          en: `Turned off (Switch 4)`,
-        },
-      };
-    }
-
-    const hasSwitch5 = device.status.some(({ code }) => code === `switch_5`);
-    if (hasSwitch5) {
-      props.store.tuya_switches.push(`switch_5`);
-      props.store.tuya_capabilities.push(`switch_5`);
-
-      props.capabilities.push(`onoff.switch_5`);
-
-      props.capabilitiesOptions[`onoff.switch_5`] = {
-        title: {
-          en: `Switch 5`
-        },
-        insightsTitleTrue: {
-          en: `Turned on (Switch 5)`,
-        },
-        insightsTitleFalse: {
-          en: `Turned off (Switch 5)`,
-        },
-      };
-    }
-
-    const hasSwitch6 = device.status.some(({ code }) => code === `switch_6`);
-    if (hasSwitch6) {
-      props.store.tuya_switches.push(`switch_6`);
-      props.store.tuya_capabilities.push(`switch_6`);
-
-      props.capabilities.push(`onoff.switch_6`);
-
-      props.capabilitiesOptions[`onoff.switch_6`] = {
-        title: {
-          en: `Switch 6`
-        },
-        insightsTitleTrue: {
-          en: `Turned on (Switch 6)`,
-        },
-        insightsTitleFalse: {
-          en: `Turned off (Switch 6)`,
-        },
-      };
-    }
-
 
     const switchCount = props.store.tuya_switches.length;
 


### PR DESCRIPTION
**Fix socket for out-of-spec switch capability**
Some sockets use the 'switch' Tuya capability for a single switch, instead of 'switch_1'.
This fix now gives these devices the 'onoff' capability

**Refactored socket switch detection**
For ease of maintenance, duplicate code was refactored.

May fix:
- #79 
- #93 