### PR TITLE
Fix lights for out-of-spec switch capability

### DIFF
--- a/app.json
+++ b/app.json
@@ -486,6 +486,62 @@
         ]
       },
       {
+        "id": "light_switch_led_turned_on",
+        "highlight": true,
+        "title": {
+          "en": "Turned light on"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch_led"
+          }
+        ]
+      },
+      {
+        "id": "light_switch_led_turned_off",
+        "highlight": true,
+        "title": {
+          "en": "Turned light off"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch_led"
+          }
+        ]
+      },
+      {
+        "id": "light_switch_turned_on",
+        "highlight": true,
+        "title": {
+          "en": "Turned other switch on"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch"
+          }
+        ]
+      },
+      {
+        "id": "light_switch_turned_off",
+        "highlight": true,
+        "title": {
+          "en": "Turned other switch off"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch"
+          }
+        ]
+      },
+      {
         "id": "socket_sub_switch_turned_off",
         "highlight": true,
         "title": {
@@ -767,6 +823,62 @@
         ]
       },
       {
+        "id": "light_switch_led_on",
+        "highlight": true,
+        "title": {
+          "en": "Turn light on"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch_led"
+          }
+        ]
+      },
+      {
+        "id": "light_switch_led_off",
+        "highlight": true,
+        "title": {
+          "en": "Turn light off"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch_led"
+          }
+        ]
+      },
+      {
+        "id": "light_switch_on",
+        "highlight": true,
+        "title": {
+          "en": "Turn other switch on"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch"
+          }
+        ]
+      },
+      {
+        "id": "light_switch_off",
+        "highlight": true,
+        "title": {
+          "en": "Turn other switch off"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch"
+          }
+        ]
+      },
+      {
         "id": "socket_sub_switch_off",
         "highlight": true,
         "title": {
@@ -828,6 +940,34 @@
       }
     ],
     "conditions": [
+      {
+        "id": "light_switch_led_is_on",
+        "highlight": true,
+        "title": {
+          "en": "Light is turned !{{on|off}}"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch_led"
+          }
+        ]
+      },
+      {
+        "id": "light_switch_is_on",
+        "highlight": true,
+        "title": {
+          "en": "Other switch is turned !{{on|off}}"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=light&capabilities=onoff.switch"
+          }
+        ]
+      },
       {
         "id": "socket_sub_switch_is_on",
         "highlight": true,

--- a/drivers/light/driver.flow.compose.json
+++ b/drivers/light/driver.flow.compose.json
@@ -35,6 +35,90 @@
           "title": { "en": "Value" }
         }
       ]
+    },
+    {
+      "id": "light_switch_led_on",
+      "$filter": "capabilities=onoff.switch_led",
+      "highlight": true,
+      "title": {
+        "en": "Turn light on"
+      }
+    },
+    {
+      "id": "light_switch_led_off",
+      "$filter": "capabilities=onoff.switch_led",
+      "highlight": true,
+      "title": {
+        "en": "Turn light off"
+      }
+    },
+    {
+      "id": "light_switch_on",
+      "$filter": "capabilities=onoff.switch",
+      "highlight": true,
+      "title": {
+        "en": "Turn other switch on"
+      }
+    },
+    {
+      "id": "light_switch_off",
+      "$filter": "capabilities=onoff.switch",
+      "highlight": true,
+      "title": {
+        "en": "Turn other switch off"
+      }
+    }
+  ],
+  "conditions": [
+    {
+      "id": "light_switch_led_is_on",
+      "$filter": "capabilities=onoff.switch_led",
+      "highlight": true,
+      "title": {
+        "en": "Light is turned !{{on|off}}"
+      }
+    },
+    {
+      "id": "light_switch_is_on",
+      "$filter": "capabilities=onoff.switch",
+      "highlight": true,
+      "title": {
+        "en": "Other switch is turned !{{on|off}}"
+      }
+    }
+  ],
+  "triggers": [
+    {
+      "id": "light_switch_led_turned_on",
+      "$filter": "capabilities=onoff.switch_led",
+      "highlight": true,
+      "title": {
+        "en": "Turned light on"
+      }
+    },
+    {
+      "id": "light_switch_led_turned_off",
+      "$filter": "capabilities=onoff.switch_led",
+      "highlight": true,
+      "title": {
+        "en": "Turned light off"
+      }
+    },
+    {
+      "id": "light_switch_turned_on",
+      "$filter": "capabilities=onoff.switch",
+      "highlight": true,
+      "title": {
+        "en": "Turned other switch on"
+      }
+    },
+    {
+      "id": "light_switch_turned_off",
+      "$filter": "capabilities=onoff.switch",
+      "highlight": true,
+      "title": {
+        "en": "Turned other switch off"
+      }
     }
   ]
 }

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -41,9 +41,86 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
   async onOAuth2Init() {
     await super.onOAuth2Init();
 
+    {
+      // switch capabilities migration
+      const tuyaSwitches = this.getStore().tuya_switches;
+
+      if (tuyaSwitches === undefined) {
+        this.log('Migrating switch capabilities...')
+        const deviceStatus = await this.getStatus();
+
+        let hasSwitchLed = false;
+        let hasSwitch = false;
+
+        const store = this.getStore();
+        const tuyaCapabilities = store.tuya_capabilities;
+        const tuyaSwitches = store.tuya_switches ?? [];
+
+        for (const status of deviceStatus) {
+          const tuyaCapability = status.code;
+          hasSwitchLed |= tuyaCapability === 'switch_led'
+          hasSwitch |= tuyaCapability === 'switch'
+
+          if (tuyaCapability === 'switch_led' || tuyaCapability === 'switch') {
+            if (!tuyaCapabilities.includes(tuyaCapability)) {
+              tuyaCapabilities.push(tuyaCapability);
+            }
+            tuyaSwitches.push(tuyaCapability);
+          }
+        }
+
+        await this.setStoreValue("tuya_capabilities", tuyaCapabilities);
+        await this.setStoreValue("tuya_switches", tuyaSwitches);
+
+        if (hasSwitch) {
+          // Capability migration needs to happen
+          if (hasSwitchLed) {
+            // Add sub-capabilities
+            await this.addCapability("onoff.switch_led");
+            await this.addCapability("onoff.switch");
+
+            await this.setCapabilityOptions("onoff.switch_led", {
+              title: {
+                en: `Light`
+              },
+              insightsTitleTrue: {
+                en: `Turned on (Light)`,
+              },
+              insightsTitleFalse: {
+                en: `Turned off (Light)`,
+              },
+            });
+            await this.setCapabilityOptions('onoff.switch', {
+              title: {
+                en: `Other`
+              },
+              insightsTitleTrue: {
+                en: `Turned on (Other)`,
+              },
+              insightsTitleFalse: {
+                en: `Turned off (Other)`,
+              },
+            });
+          } else {
+            // Add missing onoff
+            await this.addCapability("onoff");
+          }
+        }
+        this.log('Switch capabilities migration complete')
+      }
+    }
+
     // onoff
     if (this.hasCapability('onoff')) {
-      this.registerCapabilityListener('onoff', value => this.onCapabilityOnOff(value));
+      this.registerCapabilityListener('onoff', (value) => this.allOnOff(value));
+    }
+
+    const tuyaSwitches = this.getStore().tuya_switches;
+
+    for (const tuyaSwitch of tuyaSwitches) {
+      if (this.hasCapability(`onoff.${tuyaSwitch}`)) {
+        this.registerCapabilityListener(`onoff.${tuyaSwitch}`, (value) => this.switchOnOff(value, tuyaSwitch))
+      }
     }
 
     // light capabilities
@@ -59,12 +136,36 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     }
   }
 
-  async onTuyaStatus(status) {
+  async onTuyaStatus(status, changedStatusCodes) {
     await super.onTuyaStatus(status);
 
     // onoff
-    if (typeof status['switch_led'] === 'boolean') {
-      this.setCapabilityValue('onoff', status['switch_led']).catch(this.error);
+    let anySwitchOn = false;
+
+    const tuyaSwitches = this.getStore().tuya_switches;
+
+    for (const tuyaSwitch of tuyaSwitches) {
+      const switchStatus = status[tuyaSwitch];
+      const switchCapability = `onoff.${tuyaSwitch}`;
+
+      if (typeof switchStatus === 'boolean') {
+        anySwitchOn = anySwitchOn || switchStatus;
+
+        if (changedStatusCodes.includes(tuyaSwitch)) {
+          const triggerCardId = `light_${tuyaSwitch}_turned_${switchStatus ? 'on' : 'off'}`
+          const triggerCard = this.homey.flow.getDeviceTriggerCard(triggerCardId);
+
+          triggerCard.trigger(this).catch(this.error);
+        }
+
+        if (this.hasCapability(switchCapability)) {
+          this.setCapabilityValue(switchCapability, switchStatus).catch(this.error);
+        }
+      }
+    }
+
+    if (this.hasCapability('onoff')) {
+      this.setCapabilityValue('onoff', anySwitchOn).catch(this.error);
     }
 
     // light_temperature
@@ -187,9 +288,23 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     }
   }
 
-  async onCapabilityOnOff(value) {
+  async allOnOff(value) {
+    const tuyaSwitches = this.getStore().tuya_switches;
+    const commands = []
+
+    for (const tuyaSwitch of tuyaSwitches) {
+      commands.push({
+        code: tuyaSwitch,
+        value: !!value,
+      })
+    }
+
+    await this.sendCommands(commands);
+  }
+
+  async switchOnOff(value, tuya_switch) {
     await this.sendCommand({
-      code: 'switch_led',
+      code: tuya_switch,
       value: !!value,
     });
   }

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -5,6 +5,7 @@
 const TuyaOAuth2Device = require('./TuyaOAuth2Device');
 const {PIR_CAPABILITIES, LIGHT_SETTING_LABELS} = require('./TuyaLightConstants');
 const {TUYA_PERCENTAGE_SCALING} = require('./TuyaOAuth2Constants');
+const TuyaLightMigrations = require('./migrations/TuyaLightMigrations')
 
 /**
  * Device Class for Tuya Lights
@@ -41,74 +42,7 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
   async onOAuth2Init() {
     await super.onOAuth2Init();
 
-    {
-      // switch capabilities migration
-      const tuyaSwitches = this.getStore().tuya_switches;
-
-      if (tuyaSwitches === undefined) {
-        this.log('Migrating switch capabilities...')
-        const deviceStatus = await this.getStatus();
-
-        let hasSwitchLed = false;
-        let hasSwitch = false;
-
-        const store = this.getStore();
-        const tuyaCapabilities = store.tuya_capabilities;
-        const tuyaSwitches = store.tuya_switches ?? [];
-
-        for (const status of deviceStatus) {
-          const tuyaCapability = status.code;
-          hasSwitchLed |= tuyaCapability === 'switch_led'
-          hasSwitch |= tuyaCapability === 'switch'
-
-          if (tuyaCapability === 'switch_led' || tuyaCapability === 'switch') {
-            if (!tuyaCapabilities.includes(tuyaCapability)) {
-              tuyaCapabilities.push(tuyaCapability);
-            }
-            tuyaSwitches.push(tuyaCapability);
-          }
-        }
-
-        await this.setStoreValue("tuya_capabilities", tuyaCapabilities);
-        await this.setStoreValue("tuya_switches", tuyaSwitches);
-
-        if (hasSwitch) {
-          // Capability migration needs to happen
-          if (hasSwitchLed) {
-            // Add sub-capabilities
-            await this.addCapability("onoff.switch_led");
-            await this.addCapability("onoff.switch");
-
-            await this.setCapabilityOptions("onoff.switch_led", {
-              title: {
-                en: `Light`
-              },
-              insightsTitleTrue: {
-                en: `Turned on (Light)`,
-              },
-              insightsTitleFalse: {
-                en: `Turned off (Light)`,
-              },
-            });
-            await this.setCapabilityOptions('onoff.switch', {
-              title: {
-                en: `Other`
-              },
-              insightsTitleTrue: {
-                en: `Turned on (Other)`,
-              },
-              insightsTitleFalse: {
-                en: `Turned off (Other)`,
-              },
-            });
-          } else {
-            // Add missing onoff
-            await this.addCapability("onoff");
-          }
-        }
-        this.log('Switch capabilities migration complete')
-      }
-    }
+    await TuyaLightMigrations.performMigrations(this);
 
     // onoff
     if (this.hasCapability('onoff')) {

--- a/lib/TuyaOAuth2DeviceLight.js
+++ b/lib/TuyaOAuth2DeviceLight.js
@@ -39,6 +39,9 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
   LIGHT_BRIGHT_VALUE_V2_MIN = this.store.tuya_brightness_v2?.min;
   LIGHT_BRIGHT_VALUE_V2_MAX = this.store.tuya_brightness_v2?.max;
 
+  // Ensure migrations are finished before the device is used
+  initBarrier = true;
+
   async onOAuth2Init() {
     await super.onOAuth2Init();
 
@@ -68,9 +71,16 @@ class TuyaOAuth2DeviceLight extends TuyaOAuth2Device {
     if (lightCapabilities.length > 0) {
       this.registerMultipleCapabilityListener(lightCapabilities, capabilityValues => this.onCapabilitiesLight(capabilityValues), 150);
     }
+
+    this.initBarrier = false;
+    this.log('Finished oAuth2 initialization of', this.getName());
   }
 
   async onTuyaStatus(status, changedStatusCodes) {
+    while (this.initBarrier) {
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+
     await super.onTuyaStatus(status);
 
     // onoff

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -59,19 +59,95 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
         await args.device.sendSettingCommand(command)
       }
     })
+
+    // Flows for onoff.switch_led and onoff.switch
+    for (const tuyaSwitch of ["switch_led", "switch"]) {
+      this.homey.flow.getActionCard(`light_${tuyaSwitch}_on`)
+        .registerRunListener((args) => {
+          return args.device.triggerCapabilityListener(`onoff.${tuyaSwitch}`, true);
+        })
+
+      this.homey.flow.getActionCard(`light_${tuyaSwitch}_off`)
+        .registerRunListener((args) => {
+          return args.device.triggerCapabilityListener(`onoff.${tuyaSwitch}`, false);
+        })
+
+      this.homey.flow.getConditionCard(`light_${tuyaSwitch}_is_on`)
+        .registerRunListener((args) => {
+          return args.device.getCapabilityValue(`onoff.${tuyaSwitch}`);
+        });
+    }
   }
 
   onTuyaPairListDeviceProperties(device, specifications) {
     const props = super.onTuyaPairListDeviceProperties(device);
+    props.store.tuya_switches = [];
 
+    // Add this before the sub-capabilities, so it becomes the quick toggle
+    props.capabilities.push('onoff')
+
+    // onoff
     for (const status of device.status) {
       const tuyaCapability = status.code;
 
-      // onoff
       if (tuyaCapability === 'switch_led') {
+        props.store.tuya_switches.push(tuyaCapability);
         props.store.tuya_capabilities.push(tuyaCapability);
-        props.capabilities.push('onoff');
+        const homeyCapability = 'onoff.switch_led';
+        props.capabilities.push(homeyCapability);
+
+        props.capabilitiesOptions[homeyCapability] = {
+          title: {
+            en: `Light`
+          },
+          insightsTitleTrue: {
+            en: `Turned on (Light)`,
+          },
+          insightsTitleFalse: {
+            en: `Turned off (Light)`,
+          },
+        };
       }
+
+      if (tuyaCapability === 'switch') {
+        props.store.tuya_capabilities.push(tuyaCapability);
+        props.store.tuya_switches.push(tuyaCapability);
+        const homeyCapability = 'onoff.switch';
+        props.capabilities.push(homeyCapability);
+
+        props.capabilitiesOptions[homeyCapability] = {
+          title: {
+            en: `Other`
+          },
+          insightsTitleTrue: {
+            en: `Turned on (Other)`,
+          },
+          insightsTitleFalse: {
+            en: `Turned off (Other)`,
+          },
+        };
+      }
+    }
+
+    const switchCount = props.store.tuya_switches.length;
+
+    if (switchCount === 0) {
+      // Remove the 'onoff' capability
+      props.capabilities.pop()
+    } else if (switchCount === 1) {
+      // Remove the sub-capability in favor of the regular 'onoff' capability
+      props.capabilities.pop();
+    } else {
+      props.capabilitiesOptions['onoff'] = {
+        title: {
+          en: 'Switch All'
+        },
+        preventInsights: true,
+      };
+    }
+
+    for (const status of device.status) {
+      const tuyaCapability = status.code;
 
       // dim
       if (tuyaCapability === 'bright_value' || tuyaCapability === 'bright_value_v2') {

--- a/lib/migrations/TuyaLightMigrations.js
+++ b/lib/migrations/TuyaLightMigrations.js
@@ -1,0 +1,77 @@
+class TuyaLightMigrations {
+
+  static async performMigrations(device) {
+    await TuyaLightMigrations.switchCapabilityMigration(device).catch(device.error);
+  }
+
+  static async switchCapabilityMigration(device)     {
+    // switch capabilities migration
+    const tuyaSwitches = device.getStore().tuya_switches;
+
+    if (tuyaSwitches === undefined) {
+      device.log('Migrating switch capabilities...')
+      const deviceStatus = await device.getStatus();
+
+      let hasSwitchLed = false;
+      let hasSwitch = false;
+
+      const store = device.getStore();
+      const tuyaCapabilities = store.tuya_capabilities;
+      const tuyaSwitches = store.tuya_switches ?? [];
+
+      for (const status of deviceStatus) {
+        const tuyaCapability = status.code;
+        hasSwitchLed |= tuyaCapability === 'switch_led'
+        hasSwitch |= tuyaCapability === 'switch'
+
+        if (tuyaCapability === 'switch_led' || tuyaCapability === 'switch') {
+          if (!tuyaCapabilities.includes(tuyaCapability)) {
+            tuyaCapabilities.push(tuyaCapability);
+          }
+          tuyaSwitches.push(tuyaCapability);
+        }
+      }
+
+      await device.setStoreValue("tuya_capabilities", tuyaCapabilities);
+      await device.setStoreValue("tuya_switches", tuyaSwitches);
+
+      if (hasSwitch) {
+        // Capability migration needs to happen
+        if (hasSwitchLed) {
+          // Add sub-capabilities
+          await device.addCapability("onoff.switch_led");
+          await device.addCapability("onoff.switch");
+
+          await device.setCapabilityOptions("onoff.switch_led", {
+            title: {
+              en: `Light`
+            },
+            insightsTitleTrue: {
+              en: `Turned on (Light)`,
+            },
+            insightsTitleFalse: {
+              en: `Turned off (Light)`,
+            },
+          });
+          await device.setCapabilityOptions('onoff.switch', {
+            title: {
+              en: `Other`
+            },
+            insightsTitleTrue: {
+              en: `Turned on (Other)`,
+            },
+            insightsTitleFalse: {
+              en: `Turned off (Other)`,
+            },
+          });
+        } else {
+          // Add missing onoff
+          await device.addCapability("onoff");
+        }
+      }
+      device.log('Switch capabilities migration complete')
+    }
+  }
+}
+
+module.exports = TuyaLightMigrations;


### PR DESCRIPTION
**Fixed lights for out-of-spec switch capability**
Some lights appear to use the 'switch' Tuya capability alongside or instead of 'switch_led'.
These devices are now handled the same way as sockets, with a single Tuya capability resulting only in the 'onoff' Homey capability, and both capabilities resulting in two sub-capabilities and the 'onoff' capability toggling both.

**Added a migration for the fix**
Since the 'switch' capability was not handled during pairing previously a migration was added to add it to existing devices, as well as keep existing devices that don't need the fix working with the new handlers.
Since devices were sometimes synchronized before the onOAuth2Init had finished, a barrier was also added to prevent invalid states and devices becoming unavailable due to errors.

May fix:
- #74 