### PR TITLE
Add missing switch categories

### DIFF
--- a/lib/TuyaOAuth2DriverSocket.js
+++ b/lib/TuyaOAuth2DriverSocket.js
@@ -8,6 +8,8 @@ class TuyaOAuth2DriverSocket extends TuyaOAuth2Driver {
   static TUYA_DEVICE_CATEGORIES = [
     TuyaOAuth2Constants.DEVICE_CATEGORIES.ELECTRICAL_PRODUCTS.SOCKET,
     TuyaOAuth2Constants.DEVICE_CATEGORIES.ELECTRICAL_PRODUCTS.POWER_STRIP,
+    TuyaOAuth2Constants.DEVICE_CATEGORIES.ELECTRICAL_PRODUCTS.SWITCH,
+    "tdq" // Undocumented switch category
   ];
 
   async onInit() {


### PR DESCRIPTION
**Add missing switch categories**
The missing switch category 'kg' was added to the socket driver.
An undocumented category 'tdq' seems to be used by some socket devices, so it was added as well.