### PR TITLE
Add socket settings

### DIFF
--- a/.homeycompose/locales/en.json
+++ b/.homeycompose/locales/en.json
@@ -5,5 +5,6 @@
   "setting_values_unsupported": "Some of the changed values are not supported by the device:",
   "setting_unsupported": "__label__ is not supported by the device",
   "setting_value_unsupported": "Value is not supported for __label__ by the device",
-  "error_retrieving_scenes": "Could not retrieve Tuya scenes."
+  "error_retrieving_scenes": "Could not retrieve Tuya scenes.",
+  "error_setting_switch": "Failed to set switch state."
 }

--- a/app.json
+++ b/app.json
@@ -825,6 +825,32 @@
             }
           }
         ]
+      },
+      {
+        "id": "socket_child_lock",
+        "title": {
+          "en": "Set child lock"
+        },
+        "titleFormatted": {
+          "en": "Set child lock [[value]]"
+        },
+        "hint": {
+          "en": "CAUTION: This setting is not supported by every socket."
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=socket"
+          },
+          {
+            "name": "value",
+            "type": "checkbox",
+            "title": {
+              "en": "Value"
+            }
+          }
+        ]
       }
     ],
     "conditions": [

--- a/app.json
+++ b/app.json
@@ -1425,6 +1425,56 @@
       "id": "socket",
       "settings": [
         {
+          "type": "group",
+          "label": {
+            "en": "CAUTION: Some settings are not supported by every socket."
+          },
+          "children": [
+            {
+              "id": "child_lock",
+              "type": "checkbox",
+              "label": {
+                "en": "Child Lock"
+              },
+              "hint": {
+                "en": "Whether the device is prevented from being controlled locally."
+              },
+              "value": false
+            },
+            {
+              "id": "relay_status",
+              "type": "dropdown",
+              "label": {
+                "en": "Turn On Behavior"
+              },
+              "hint": {
+                "en": "What status the device takes on when plugged in."
+              },
+              "value": "last",
+              "values": [
+                {
+                  "id": "power_on",
+                  "label": {
+                    "en": "On"
+                  }
+                },
+                {
+                  "id": "power_off",
+                  "label": {
+                    "en": "Off"
+                  }
+                },
+                {
+                  "id": "last",
+                  "label": {
+                    "en": "Last Status"
+                  }
+                }
+              ]
+            }
+          ]
+        },
+        {
           "id": "power_scaling",
           "type": "dropdown",
           "label": {

--- a/drivers/socket/driver.flow.compose.json
+++ b/drivers/socket/driver.flow.compose.json
@@ -43,6 +43,25 @@
           "placeholder": { "en": "Switch 1" }
         }
       ]
+    },
+    {
+      "id": "socket_child_lock",
+      "title": {
+        "en": "Set child lock"
+      },
+      "titleFormatted": {
+        "en": "Set child lock [[value]]"
+      },
+      "hint": {
+        "en": "CAUTION: This setting is not supported by every socket."
+      },
+      "args": [
+        {
+          "name": "value",
+          "type": "checkbox",
+          "title": { "en": "Value" }
+        }
+      ]
     }
   ],
   "conditions": [

--- a/drivers/socket/driver.settings.compose.json
+++ b/drivers/socket/driver.settings.compose.json
@@ -1,5 +1,55 @@
 [
   {
+    "type": "group",
+    "label": {
+      "en": "CAUTION: Some settings are not supported by every socket."
+    },
+    "children": [
+      {
+        "id": "child_lock",
+        "type": "checkbox",
+        "label": {
+          "en": "Child Lock"
+        },
+        "hint": {
+          "en": "Whether the device is prevented from being controlled locally."
+        },
+        "value": false
+      },
+      {
+        "id": "relay_status",
+        "type": "dropdown",
+        "label": {
+          "en": "Turn On Behavior"
+        },
+        "hint": {
+          "en": "What status the device takes on when plugged in."
+        },
+        "value": "last",
+        "values": [
+          {
+            "id": "power_on",
+            "label": {
+              "en": "On"
+            }
+          },
+          {
+            "id": "power_off",
+            "label": {
+              "en": "Off"
+            }
+          },
+          {
+            "id": "last",
+            "label": {
+              "en": "Last Status"
+            }
+          }
+        ]
+      }
+    ]
+  },
+  {
     "id": "power_scaling",
     "type": "dropdown",
     "label": {

--- a/lib/TuyaOAuth2DeviceSocket.js
+++ b/lib/TuyaOAuth2DeviceSocket.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const TuyaOAuth2Device = require('./TuyaOAuth2Device');
+const TuyaOAuth2Util = require('./TuyaOAuth2Util');
+const { SOCKET_SETTING_LABELS} = require('./TuyaSocketConstants');
 
 /**
  * Device Class for Tuya Sockets
@@ -85,6 +87,15 @@ class TuyaOAuth2DeviceSocket extends TuyaOAuth2Device {
       const cur_current = status['cur_current'] / 1000.0;
       this.setCapabilityValue('measure_current', cur_current).catch(this.error);
     }
+
+    for (const setting of ["child_lock", "relay_status"]) {
+      const settingValue = status[setting];
+      if (settingValue !== undefined) {
+        await this.setSettings({
+          [setting]: settingValue,
+        })
+      }
+    }
   }
 
   async allOnOff(value) {
@@ -106,6 +117,10 @@ class TuyaOAuth2DeviceSocket extends TuyaOAuth2Device {
       code: tuya_switch,
       value: !!value,
     });
+  }
+
+  async onSettings(event) {
+    return TuyaOAuth2Util.onSettings(this, event, SOCKET_SETTING_LABELS)
   }
 }
 

--- a/lib/TuyaOAuth2DeviceSocket.js
+++ b/lib/TuyaOAuth2DeviceSocket.js
@@ -120,7 +120,7 @@ class TuyaOAuth2DeviceSocket extends TuyaOAuth2Device {
   }
 
   async onSettings(event) {
-    return TuyaOAuth2Util.onSettings(this, event, SOCKET_SETTING_LABELS)
+    return await TuyaOAuth2Util.onSettings(this, event, SOCKET_SETTING_LABELS);
   }
 }
 

--- a/lib/TuyaOAuth2DriverSocket.js
+++ b/lib/TuyaOAuth2DriverSocket.js
@@ -63,9 +63,9 @@ class TuyaOAuth2DriverSocket extends TuyaOAuth2Driver {
       });
 
     // Register setting flows
-    this.homey.flow.getActionCard('socket_child_lock').registerRunListener(async (args) => {
-      return TuyaOAuth2Util.sendSetting(args.device, "child_lock", args.value, SOCKET_SETTING_LABELS)
-    })
+    this.homey.flow
+      .getActionCard('socket_child_lock')
+      .registerRunListener((args) => TuyaOAuth2Util.sendSetting(args.device, "child_lock", args.value, SOCKET_SETTING_LABELS));
   }
 
   onTuyaPairListDeviceProperties(device) {

--- a/lib/TuyaOAuth2DriverSocket.js
+++ b/lib/TuyaOAuth2DriverSocket.js
@@ -2,6 +2,8 @@
 
 const TuyaOAuth2Driver = require('./TuyaOAuth2Driver');
 const TuyaOAuth2Constants = require('./TuyaOAuth2Constants');
+const TuyaOAuth2Util = require('./TuyaOAuth2Util');
+const { SOCKET_SETTING_LABELS} = require('./TuyaSocketConstants');
 
 class TuyaOAuth2DriverSocket extends TuyaOAuth2Driver {
 
@@ -55,6 +57,11 @@ class TuyaOAuth2DriverSocket extends TuyaOAuth2Driver {
         const homeyCapability = `onoff.switch_${args.switch.id.substring(7)}`;
         return args.device.getCapabilityValue(homeyCapability);
       });
+
+    // Register setting flows
+    this.homey.flow.getActionCard('socket_child_lock').registerRunListener(async (args) => {
+      return TuyaOAuth2Util.sendSetting(args.device, "child_lock", args.value, SOCKET_SETTING_LABELS)
+    })
   }
 
   onTuyaPairListDeviceProperties(device) {

--- a/lib/TuyaOAuth2DriverSocket.js
+++ b/lib/TuyaOAuth2DriverSocket.js
@@ -15,14 +15,6 @@ class TuyaOAuth2DriverSocket extends TuyaOAuth2Driver {
   async onInit() {
     await super.onInit();
 
-    this.homey.flow.getActionCard('socket_sub_switch_on').registerRunListener(async (args) => {
-      await args.device.switchOnOff(true, args.switch.id).catch(this.error);
-    })
-
-    this.homey.flow.getActionCard('socket_sub_switch_off').registerRunListener(async (args) => {
-      await args.device.switchOnOff(false, args.switch.id).catch(this.error);
-    })
-
     const switchAutocompleteListener = (query, args) => {
       const device = args.device;
       const tuyaSwitches = device.getStore().tuya_switches;
@@ -38,10 +30,22 @@ class TuyaOAuth2DriverSocket extends TuyaOAuth2Driver {
 
     // Register Socket switch flows
     this.homey.flow.getActionCard('socket_sub_switch_on')
-      .registerArgumentAutocompleteListener('switch', (query, args) => switchAutocompleteListener(query, args));
+      .registerArgumentAutocompleteListener('switch', (query, args) => switchAutocompleteListener(query, args))
+      .registerRunListener(async (args) => {
+        await args.device.switchOnOff(true, args.switch.id).catch((err) => {
+          this.error(err);
+          throw new Error(this.homey.__("error_setting_switch"));
+        });
+      });
 
     this.homey.flow.getActionCard('socket_sub_switch_off')
-      .registerArgumentAutocompleteListener('switch', (query, args) => switchAutocompleteListener(query, args));
+      .registerArgumentAutocompleteListener('switch', (query, args) => switchAutocompleteListener(query, args))
+      .registerRunListener(async (args) => {
+      await args.device.switchOnOff(false, args.switch.id).catch((err) => {
+        this.error(err);
+        throw new Error(this.homey.__("error_setting_switch"));
+      });
+    });
 
     this.homey.flow.getDeviceTriggerCard('socket_sub_switch_turned_on')
       .registerArgumentAutocompleteListener('switch', (query, args) => switchAutocompleteListener(query, args))

--- a/lib/TuyaOAuth2Util.js
+++ b/lib/TuyaOAuth2Util.js
@@ -114,7 +114,7 @@ class TuyaOAuth2Util {
    * @param code - The Tuya code of the setting
    * @param value - The new value of the setting
    * @param settingLabels - A mapping from setting keys to their user-friendly label
-   * */
+   */
   static async sendSetting(device, code, value, settingLabels) {
     await device
       .sendCommand({
@@ -144,7 +144,7 @@ class TuyaOAuth2Util {
    * Send basic settings to the given device
    * @param device - The device for which the settings are updated
    * @param event - The settings event
-   * */
+   */
   static async sendSettings(device, { oldSettings, newSettings, changedKeys }) {
     const unsupportedSettings = [];
     const unsupportedValues = [];
@@ -175,7 +175,7 @@ class TuyaOAuth2Util {
    * @param unsupportedSettings - Settings that are wholly unsupported
    * @param unsupportedValues - Settings for which the new value is unsupported
    * @param settingLabels - A mapping from setting keys to their user-friendly label
-   * */
+   */
   static reportUnsupportedSettings(device, unsupportedSettings, unsupportedValues, settingLabels) {
     // Report back which capabilities and values are unsupported,
     // since we cannot programmatically remove settings.
@@ -203,7 +203,7 @@ class TuyaOAuth2Util {
    * @param device - The device for which the settings are updated
    * @param event - The settings event
    * @param settingLabels - A mapping from setting keys to their user-friendly label
-   * */
+   */
   static async onSettings(device, event, settingLabels) {
     const [unsupportedSettings, unsupportedValues] = await TuyaOAuth2Util.sendSettings(device, event);
     return TuyaOAuth2Util.reportUnsupportedSettings(device, unsupportedSettings, unsupportedValues, settingLabels);

--- a/lib/TuyaOAuth2Util.js
+++ b/lib/TuyaOAuth2Util.js
@@ -108,6 +108,74 @@ class TuyaOAuth2Util {
     }
   }
 
+  /**
+   * Send basic settings to the given device
+   * @param device - The device for which the settings are updated
+   * @param event - The settings event
+   * */
+  static async sendSettings(device, { oldSettings, newSettings, changedKeys }) {
+    const unsupportedSettings = [];
+    const unsupportedValues = [];
+
+    // Accumulate rejected settings so the user can be notified gracefully
+    for (const changedKey of changedKeys) {
+      const newValue = newSettings[changedKey];
+      await device.sendCommand({
+        code: changedKey,
+        value: newValue,
+      }).catch((err) => {
+        if (err.tuyaCode === 2008) {
+          unsupportedSettings.push(changedKey);
+        } else if (err.tuyaCode === 501) {
+          unsupportedValues.push(changedKey);
+        } else {
+          throw err;
+        }
+      });
+    }
+
+    return [unsupportedSettings, unsupportedValues];
+  }
+
+  /**
+   * Combine unsupported settings into a message for the user
+   * @param device - The device for which the settings are updated
+   * @param unsupportedSettings - Settings that are wholly unsupported
+   * @param unsupportedValues - Settings for which the new value is unsupported
+   * @param settingLabels - A mapping from setting keys to their user-friendly label
+   * */
+  static reportUnsupportedSettings(device, unsupportedSettings, unsupportedValues, settingLabels) {
+    // Report back which capabilities and values are unsupported,
+    // since we cannot programmatically remove settings.
+    const messages = [];
+
+    if (unsupportedSettings.length > 0) {
+      const mappedSettingNames = unsupportedSettings.map(
+        (settingKey) => settingLabels[settingKey],
+      );
+      messages.push(device.homey.__("settings_unsupported") + " " + mappedSettingNames.join(", "));
+    }
+    if (unsupportedValues.length > 0) {
+      const mappedSettingNames = unsupportedValues.map(
+        (settingKey) => settingLabels[settingKey],
+      );
+      messages.push(device.homey.__("setting_values_unsupported") + " " + mappedSettingNames.join(", "));
+    }
+    if (messages.length > 0) {
+      return messages.join("\n");
+    }
+  }
+
+  /**
+   * Handles basic settings
+   * @param device - The device for which the settings are updated
+   * @param event - The settings event
+   * @param settingLabels - A mapping from setting keys to their user-friendly label
+   * */
+  static async onSettings(device, event, settingLabels) {
+    const [unsupportedSettings, unsupportedValues] = await TuyaOAuth2Util.sendSettings(device, event);
+    return TuyaOAuth2Util.reportUnsupportedSettings(device, unsupportedSettings, unsupportedValues, settingLabels);
+  }
 }
 
 module.exports = TuyaOAuth2Util;

--- a/lib/TuyaOAuth2Util.js
+++ b/lib/TuyaOAuth2Util.js
@@ -109,6 +109,38 @@ class TuyaOAuth2Util {
   }
 
   /**
+   * Send basic setting to the given device, throwing an error for the user if it or the new value is unsupported
+   * @param device - The device for which the settings are updated
+   * @param code - The Tuya code of the setting
+   * @param value - The new value of the setting
+   * @param settingLabels - A mapping from setting keys to their user-friendly label
+   * */
+  static async sendSetting(device, code, value, settingLabels) {
+    await device
+      .sendCommand({
+        code: code,
+        value: value,
+      })
+      .catch((err) => {
+        if (err.tuyaCode === 2008) {
+          throw new Error(
+            device.homey.__("setting_unsupported", {
+              label: settingLabels[code],
+            }),
+          );
+        } else if (err.tuyaCode === 501) {
+          throw new Error(
+            device.homey.__("setting_value_unsupported", {
+              label: settingLabels[code],
+            }),
+          );
+        } else {
+          throw err;
+        }
+      });
+  }
+
+  /**
    * Send basic settings to the given device
    * @param device - The device for which the settings are updated
    * @param event - The settings event

--- a/lib/TuyaSocketConstants.js
+++ b/lib/TuyaSocketConstants.js
@@ -1,0 +1,10 @@
+'use strict'
+
+class TuyaSocketConstants {
+  static SOCKET_SETTING_LABELS = {
+    child_lock: "Child Lock",
+    relay_status: "Turn On Behavior"
+  }
+}
+
+module.exports = TuyaSocketConstants;

--- a/locales/en.json
+++ b/locales/en.json
@@ -12,5 +12,6 @@
   "setting_values_unsupported": "Some of the changed values are not supported by the device:",
   "setting_unsupported": "__label__ is not supported by the device",
   "setting_value_unsupported": "Value is not supported for __label__ by the device",
-  "error_retrieving_scenes": "Could not retrieve Tuya scenes."
+  "error_retrieving_scenes": "Could not retrieve Tuya scenes.",
+  "error_setting_switch": "Failed to set switch state."
 }


### PR DESCRIPTION
**Added socket settings**
Added the 'child_lock' and 'relay_status' Tuya capabilities as settings, with an action flow for the child lock.

**Added reusable setting handlers**
Since the new onSettings would need similar code as found in other handlers,
a few reusable handlers were added in TuyaOAuth2Util.
The similar handlers can be refactored to use these at a later point.

**Fixed socket sub-switch flow runListeners**
Errors in the action flows for sub-sockets were caught, meaning the flow card succeeded on an error.
Now a user-friendly error is thrown instead, with the original error being logged.