### PR TITLE
Quick fix fan dim capability range

### DIFF
--- a/lib/TuyaOAuth2DriverFan.js
+++ b/lib/TuyaOAuth2DriverFan.js
@@ -14,7 +14,7 @@ class TuyaOAuth2DriverFan extends TuyaOAuth2Driver {
     // TODO
   ];
 
-  onTuyaPairListDeviceProperties(device) {
+  onTuyaPairListDeviceProperties(device, deviceSpecs) {
     const props = super.onTuyaPairListDeviceProperties(device);
 
     // onoff
@@ -27,12 +27,26 @@ class TuyaOAuth2DriverFan extends TuyaOAuth2Driver {
     const hasFanSpeedPercent = device.status.some(({ code }) => code === 'fan_speed_percent');
     if (hasFanSpeedPercent) {
       props.capabilities.push('dim');
-      props.capabilitiesOptions = props.capabilitiesOptions ?? {};
       props.capabilitiesOptions['dim'] = {
-        max: 1,
+        min: 1,
         max: 6,
         step: 1
       };
+    }
+
+    // Device Specifications
+    for (const functionSpecification of specifications.functions) {
+      const tuyaCapability = functionSpecification.code;
+      const values = JSON.parse(functionSpecification.values);
+
+      if (tuyaCapability === 'fan_speed_percent') {
+        props.store.tuya_brightness = values;
+        props.capabilitiesOptions['dim'] = {
+          min: values.min ?? 1,
+          max: values.max ?? 100,
+          step: values.step ?? 1,
+        }
+      }
     }
 
     return props;


### PR DESCRIPTION
**Quick fix fan dim capability range**
The range of the dim capability defined max twice, instead of a min and a max.
Since the documentation says the range should be [1, 100] the device specification is now also used if present.
Since I don't have a test device the default was left as is, being [1, 6], but this should be looked at at some point.