### PR TITLE
Add a generic set of capabilities to each driver.compose

### DIFF
--- a/app.json
+++ b/app.json
@@ -1052,7 +1052,10 @@
       "id": "doorbell"
     },
     {
-      "capabilities": [],
+      "capabilities": [
+        "onoff",
+        "dim"
+      ],
       "connectivity": [
         "cloud"
       ],
@@ -1101,7 +1104,13 @@
       "id": "fan"
     },
     {
-      "capabilities": [],
+      "capabilities": [
+        "onoff",
+        "dim",
+        "light_temperature",
+        "light_hue",
+        "light_saturation"
+      ],
       "connectivity": [
         "cloud"
       ],
@@ -1365,7 +1374,9 @@
       ]
     },
     {
-      "capabilities": [],
+      "capabilities": [
+        "alarm_contact"
+      ],
       "connectivity": [
         "cloud"
       ],
@@ -1415,7 +1426,9 @@
       "id": "sensor_contact"
     },
     {
-      "capabilities": [],
+      "capabilities": [
+        "alarm_motion"
+      ],
       "connectivity": [
         "cloud"
       ],
@@ -1465,7 +1478,9 @@
       "id": "sensor_motion"
     },
     {
-      "capabilities": [],
+      "capabilities": [
+        "alarm_smoke"
+      ],
       "connectivity": [
         "cloud"
       ],
@@ -1515,7 +1530,10 @@
       "id": "sensor_smoke"
     },
     {
-      "capabilities": [],
+      "capabilities": [
+        "onoff",
+        "measure_power"
+      ],
       "connectivity": [
         "cloud"
       ],

--- a/drivers/fan/driver.compose.json
+++ b/drivers/fan/driver.compose.json
@@ -3,5 +3,9 @@
   "class": "fan",
   "name": {
     "en": "Fan"
-  }
+  },
+  "capabilities": [
+    "onoff",
+    "dim"
+  ]
 }

--- a/drivers/light/driver.compose.json
+++ b/drivers/light/driver.compose.json
@@ -4,5 +4,12 @@
   "name": {
     "en": "Light",
     "nl": "Lamp"
-  }
+  },
+  "capabilities": [
+    "onoff",
+    "dim",
+    "light_temperature",
+    "light_hue",
+    "light_saturation"
+  ]
 }

--- a/drivers/sensor_contact/driver.compose.json
+++ b/drivers/sensor_contact/driver.compose.json
@@ -4,5 +4,8 @@
   "name": {
     "en": "Door Sensor",
     "nl": "Deur Sensor"
-  }
+  },
+  "capabilities": [
+    "alarm_contact"
+  ]
 }

--- a/drivers/sensor_motion/driver.compose.json
+++ b/drivers/sensor_motion/driver.compose.json
@@ -4,5 +4,8 @@
   "name": {
     "en": "Motion Sensor",
     "nl": "Bewegingssensor"
-  }
+  },
+  "capabilities": [
+    "alarm_motion"
+  ]
 }

--- a/drivers/sensor_smoke/driver.compose.json
+++ b/drivers/sensor_smoke/driver.compose.json
@@ -4,5 +4,8 @@
   "name": {
     "en": "Smoke Detector",
     "nl": "Rookmelder"
-  }
+  },
+  "capabilities": [
+    "alarm_smoke"
+  ]
 }

--- a/drivers/socket/driver.compose.json
+++ b/drivers/socket/driver.compose.json
@@ -4,5 +4,9 @@
   "name": {
     "en": "Plug",
     "nl": "Plug"
-  }
+  },
+  "capabilities": [
+    "onoff",
+    "measure_power"
+  ]
 }


### PR DESCRIPTION
**Add a generic set of capabilities to each driver.compose**
Added a few basic capabilities that most represent each device to their respective driver.compose.json files.
This ensures that the store page of the app shows some applicable flows to give an impression of what devices can do.