### PR TITLE
Handle missing specifications gracefully

### DIFF
--- a/drivers/dimmer/driver.js
+++ b/drivers/dimmer/driver.js
@@ -119,6 +119,10 @@ class TuyaOAuth2DriverDimmer extends TuyaOAuth2Driver {
       }
     }
 
+    if (!specification || !specification.status) {
+      return props;
+    }
+
     for (const statusSpecification of specification.status) {
       const tuyaCapability = statusSpecification.code;
       const values = JSON.parse(statusSpecification.values);

--- a/drivers/heater/driver.js
+++ b/drivers/heater/driver.js
@@ -40,6 +40,10 @@ class TuyaOAuth2DriverHeater extends TuyaOAuth2Driver {
       }
     }
 
+    if (!specification || !specification.functions) {
+      return props;
+    }
+
     for (const functionSpecification of specification.functions) {
       if (functionSpecification.code === 'temp_set') {
         const tempSetSpecs = JSON.parse(functionSpecification.values);

--- a/lib/TuyaOAuth2Driver.js
+++ b/lib/TuyaOAuth2Driver.js
@@ -20,7 +20,9 @@ class TuyaOAuth2Driver extends OAuth2Driver {
       });
     const listDevices = [];
     for (const device of filteredDevices) {
-      const deviceSpecs = await oAuth2Client.getSpecification({deviceId: device.id});
+      const deviceSpecs = await oAuth2Client.getSpecification({deviceId: device.id})
+          .catch(e => this.log('Device specification retrieval failed', e));
+
       const deviceProperties = this.onTuyaPairListDeviceProperties({...device}, deviceSpecs);
       listDevices.push({
         name: device.name,

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -202,7 +202,7 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     // Category Specifications
     // The main light category has both (0,255) and (0,1000) for backwards compatibility
     // Other categories use only (0,1000)
-    if (specifications && specifications.category === "dj") {
+    if (device.category === "dj") {
       props.store.tuya_brightness = { min: 25, max: 255, scale: 0, step: 1}
       props.store.tuya_temperature = { min: 0, max: 255, scale: 0, step: 1}
       props.store.tuya_colour = {

--- a/lib/TuyaOAuth2DriverLight.js
+++ b/lib/TuyaOAuth2DriverLight.js
@@ -202,7 +202,7 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
     // Category Specifications
     // The main light category has both (0,255) and (0,1000) for backwards compatibility
     // Other categories use only (0,1000)
-    if (specifications.category === "dj") {
+    if (specifications && specifications.category === "dj") {
       props.store.tuya_brightness = { min: 25, max: 255, scale: 0, step: 1}
       props.store.tuya_temperature = { min: 0, max: 255, scale: 0, step: 1}
       props.store.tuya_colour = {
@@ -225,6 +225,10 @@ class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
         s:{min: 0, max: 1000, scale: 0, step: 1},
         v:{min: 0, max: 1000, scale: 0, step: 1},
       }
+    }
+
+    if (!specifications || !specifications.functions) {
+      return props;
     }
 
     // Device Specifications


### PR DESCRIPTION
Ignore failures retrieving the specification, and handle a missing value gracefully. Might be related to #129 and #131.