### PR TITLE
Fix malformed json in sendCommands

### DIFF
--- a/lib/TuyaOAuth2Client.ts
+++ b/lib/TuyaOAuth2Client.ts
@@ -252,7 +252,7 @@ export default class TuyaOAuth2Client extends OAuth2Client<TuyaOAuth2Token> {
 
   async sendCommands({ deviceId, commands = [] }: { deviceId: string; commands: TuyaCommand[] }): Promise<boolean> {
     // https://developer.tuya.com/en/docs/cloud/device-control?id=K95zu01ksols7
-    return this._post(`/v1.0/devices/${deviceId}/commands`, commands).catch(err => {
+    return this._post(`/v1.0/devices/${deviceId}/commands`, { commands: commands }).catch(err => {
       if (err.tuyaCode === TuyaOAuth2Constants.ERROR_CODES.DEVICE_OFFLINE) {
         throw new Error(this.homey.__('device_offline'));
       }


### PR DESCRIPTION
**- Fixed malformed json in sendCommands**
The object surrounding the commands being sent was lost during a refactor. It has been added again.