### PR TITLE
Fixed setondim for lights with other switch

### DIFF
--- a/drivers/light/driver.ts
+++ b/drivers/light/driver.ts
@@ -150,6 +150,7 @@ module.exports = class TuyaOAuth2DriverLight extends TuyaOAuth2Driver {
         title: {
           en: 'Switch All',
         },
+        setOnDim: false,
         preventInsights: true,
       };
     }

--- a/lib/migrations/TuyaLightMigrations.ts
+++ b/lib/migrations/TuyaLightMigrations.ts
@@ -84,7 +84,15 @@ async function switchCapabilityMigration(device: TuyaOAuth2DeviceLight): Promise
 
 async function otherSwitchOnDimMigration(device: TuyaOAuth2DeviceLight): Promise<void> {
   // Add setOnDim: false to onoff for devices that have an additional switch
-  const capabilityOptions = device.getCapabilityOptions('onoff');
+
+  // The Homey API throws an error if no capability options have been set before
+  let capabilityOptions;
+  try {
+    capabilityOptions = device.getCapabilityOptions('onoff');
+  } catch (err) {
+    capabilityOptions = {};
+  }
+
   const tuyaSwitches = device.getStore().tuya_switches;
 
   if (tuyaSwitches.length > 1 && capabilityOptions?.setOnDim !== false) {


### PR DESCRIPTION
**- Fixed setondim for lights with other switch**
In lights with another switch in addition to the light, turning the light on or off using the dim capability also turns the other switch on or off.
To prevent his setOnDim is now false if multiple onoff capabilities are used.
A migration fixes this for existing devices.