### PR TITLE
Fixed sensor reset

### DIFF
--- a/.homeycompose/drivers/settings/alarmTimeout.json
+++ b/.homeycompose/drivers/settings/alarmTimeout.json
@@ -1,0 +1,12 @@
+{
+  "id": "alarm_timeout",
+  "type": "number",
+  "label": {
+    "en": "Alarm Timeout"
+  },
+  "value": 10,
+  "min": 1,
+  "units": {
+    "en": "seconds"
+  }
+}

--- a/.homeycompose/drivers/settings/useAlarmTimeout.json
+++ b/.homeycompose/drivers/settings/useAlarmTimeout.json
@@ -1,0 +1,11 @@
+{
+  "id": "use_alarm_timeout",
+  "type": "checkbox",
+  "hint": {
+    "en": "Turn the alarm off a set time after the start signal, even if no end signal is received."
+  },
+  "label": {
+    "en": "Use Alarm Timeout"
+  },
+  "value": false
+}

--- a/app.json
+++ b/app.json
@@ -2806,6 +2806,29 @@
       "id": "sensor_contact",
       "settings": [
         {
+          "id": "use_alarm_timeout",
+          "type": "checkbox",
+          "hint": {
+            "en": "Turn the alarm off a set time after the start signal, even if no end signal is received."
+          },
+          "label": {
+            "en": "Use Alarm Timeout"
+          },
+          "value": false
+        },
+        {
+          "id": "alarm_timeout",
+          "type": "number",
+          "label": {
+            "en": "Alarm Timeout"
+          },
+          "value": 10,
+          "min": 1,
+          "units": {
+            "en": "seconds"
+          }
+        },
+        {
           "id": "deviceSpecification",
           "type": "label",
           "label": {
@@ -2871,6 +2894,29 @@
       "id": "sensor_motion",
       "settings": [
         {
+          "id": "use_alarm_timeout",
+          "type": "checkbox",
+          "hint": {
+            "en": "Turn the alarm off a set time after the start signal, even if no end signal is received."
+          },
+          "label": {
+            "en": "Use Alarm Timeout"
+          },
+          "value": false
+        },
+        {
+          "id": "alarm_timeout",
+          "type": "number",
+          "label": {
+            "en": "Alarm Timeout"
+          },
+          "value": 10,
+          "min": 1,
+          "units": {
+            "en": "seconds"
+          }
+        },
+        {
           "id": "deviceSpecification",
           "type": "label",
           "label": {
@@ -2935,6 +2981,29 @@
       },
       "id": "sensor_smoke",
       "settings": [
+        {
+          "id": "use_alarm_timeout",
+          "type": "checkbox",
+          "hint": {
+            "en": "Turn the alarm off a set time after the start signal, even if no end signal is received."
+          },
+          "label": {
+            "en": "Use Alarm Timeout"
+          },
+          "value": false
+        },
+        {
+          "id": "alarm_timeout",
+          "type": "number",
+          "label": {
+            "en": "Alarm Timeout"
+          },
+          "value": 10,
+          "min": 1,
+          "units": {
+            "en": "seconds"
+          }
+        },
         {
           "id": "deviceSpecification",
           "type": "label",

--- a/drivers/camera/driver.settings.compose.json
+++ b/drivers/camera/driver.settings.compose.json
@@ -189,16 +189,7 @@
     ]
   },
   {
-    "id": "alarm_timeout",
-    "type": "number",
-    "label": {
-      "en": "Alarm Timeout"
-    },
-    "value": 10,
-    "min": 1,
-    "units": {
-      "en": "seconds"
-    }
+    "$extends": "alarmTimeout"
   },
   {
     "$extends": "deviceSpecification"

--- a/drivers/sensor_contact/device.ts
+++ b/drivers/sensor_contact/device.ts
@@ -6,8 +6,11 @@ module.exports = class TuyaOAuth2DeviceSensorContact extends TuyaOAuth2DeviceSen
     await super.onTuyaStatus(status, changedStatusCodes);
 
     // alarm_contact
-    if (typeof status['doorcontact_state'] === 'boolean') {
-      this.setCapabilityValue('alarm_contact', status['doorcontact_state']).catch(this.error);
+    if (
+      typeof status['doorcontact_state'] === 'boolean' &&
+      (!this.getSetting('use_alarm_timeout') || changedStatusCodes.includes('doorcontact_state'))
+    ) {
+      this.setAlarmCapabilityValue('alarm_contact', status['doorcontact_state']).catch(this.error);
     }
   }
 };

--- a/drivers/sensor_contact/device.ts
+++ b/drivers/sensor_contact/device.ts
@@ -2,6 +2,12 @@ import TuyaOAuth2DeviceSensor from '../../lib/TuyaOAuth2DeviceSensor';
 import { TuyaStatus } from '../../types/TuyaTypes';
 
 module.exports = class TuyaOAuth2DeviceSensorContact extends TuyaOAuth2DeviceSensor {
+  async onOAuth2Init(): Promise<void> {
+    await this.initAlarm('alarm_contact').catch(this.error);
+
+    return super.onOAuth2Init();
+  }
+
   async onTuyaStatus(status: TuyaStatus, changedStatusCodes: string[]): Promise<void> {
     await super.onTuyaStatus(status, changedStatusCodes);
 

--- a/drivers/sensor_contact/driver.settings.compose.json
+++ b/drivers/sensor_contact/driver.settings.compose.json
@@ -1,5 +1,11 @@
 [
   {
+    "$extends": "useAlarmTimeout"
+  },
+  {
+    "$extends": "alarmTimeout"
+  },
+  {
     "$extends": "deviceSpecification"
   }
 ]

--- a/drivers/sensor_motion/device.ts
+++ b/drivers/sensor_motion/device.ts
@@ -2,6 +2,12 @@ import TuyaOAuth2DeviceSensor from '../../lib/TuyaOAuth2DeviceSensor';
 import { TuyaStatus } from '../../types/TuyaTypes';
 
 module.exports = class TuyaOAuth2DeviceSensorMotion extends TuyaOAuth2DeviceSensor {
+  async onOAuth2Init(): Promise<void> {
+    await this.initAlarm('alarm_motion').catch(this.error);
+
+    return super.onOAuth2Init();
+  }
+
   async onTuyaStatus(status: TuyaStatus, changedStatusCodes: string[]): Promise<void> {
     await super.onTuyaStatus(status, changedStatusCodes);
 

--- a/drivers/sensor_motion/device.ts
+++ b/drivers/sensor_motion/device.ts
@@ -6,8 +6,11 @@ module.exports = class TuyaOAuth2DeviceSensorMotion extends TuyaOAuth2DeviceSens
     await super.onTuyaStatus(status, changedStatusCodes);
 
     // alarm_motion
-    if (typeof status['pir'] === 'string') {
-      this.setCapabilityValue('alarm_motion', status['pir'] === 'pir').catch(this.error);
+    if (
+      typeof status['pir'] === 'string' &&
+      (!this.getSetting('use_alarm_timeout') || changedStatusCodes.includes('pir'))
+    ) {
+      this.setAlarmCapabilityValue('alarm_motion', status['pir'] === 'pir').catch(this.error);
     }
   }
 };

--- a/drivers/sensor_motion/driver.settings.compose.json
+++ b/drivers/sensor_motion/driver.settings.compose.json
@@ -1,5 +1,11 @@
 [
   {
+    "$extends": "useAlarmTimeout"
+  },
+  {
+    "$extends": "alarmTimeout"
+  },
+  {
     "$extends": "deviceSpecification"
   }
 ]

--- a/drivers/sensor_motion/driver.ts
+++ b/drivers/sensor_motion/driver.ts
@@ -24,6 +24,20 @@ module.exports = class TuyaOAuth2DriverSensorMotion extends TuyaOAuth2DriverSens
       props.capabilities.push('alarm_motion');
     }
 
+    if (!specifications) {
+      return props;
+    }
+
+    for (const specification of specifications.status) {
+      const tuyaCapability = specification.code;
+      const values = JSON.parse(specification.values);
+      if (tuyaCapability === 'pir') {
+        if (!values.range.includes('none')) {
+          props.settings['use_alarm_timeout'] = true;
+        }
+      }
+    }
+
     return props;
   }
 };

--- a/drivers/sensor_smoke/device.ts
+++ b/drivers/sensor_smoke/device.ts
@@ -6,8 +6,11 @@ module.exports = class TuyaOAuth2DeviceSensorSmoke extends TuyaOAuth2DeviceSenso
     await super.onTuyaStatus(status, changedStatusCodes);
 
     // alarm_smoke
-    if (typeof status['smoke_sensor_status'] === 'string') {
-      this.setCapabilityValue('alarm_smoke', status['smoke_sensor_status'] === 'alarm').catch(this.error);
+    if (
+      typeof status['smoke_sensor_status'] === 'string' &&
+      (!this.getSetting('use_alarm_timeout') || changedStatusCodes.includes('smoke_sensor_status'))
+    ) {
+      this.setAlarmCapabilityValue('alarm_smoke', status['smoke_sensor_status'] === 'alarm').catch(this.error);
     }
   }
 };

--- a/drivers/sensor_smoke/device.ts
+++ b/drivers/sensor_smoke/device.ts
@@ -2,6 +2,12 @@ import TuyaOAuth2DeviceSensor from '../../lib/TuyaOAuth2DeviceSensor';
 import { TuyaStatus } from '../../types/TuyaTypes';
 
 module.exports = class TuyaOAuth2DeviceSensorSmoke extends TuyaOAuth2DeviceSensor {
+  async onOAuth2Init(): Promise<void> {
+    await this.initAlarm('alarm_smoke').catch(this.error);
+
+    return super.onOAuth2Init();
+  }
+
   async onTuyaStatus(status: TuyaStatus, changedStatusCodes: string[]): Promise<void> {
     await super.onTuyaStatus(status, changedStatusCodes);
 

--- a/drivers/sensor_smoke/driver.settings.compose.json
+++ b/drivers/sensor_smoke/driver.settings.compose.json
@@ -1,5 +1,11 @@
 [
   {
+    "$extends": "useAlarmTimeout"
+  },
+  {
+    "$extends": "alarmTimeout"
+  },
+  {
     "$extends": "deviceSpecification"
   }
 ]

--- a/drivers/sensor_smoke/driver.ts
+++ b/drivers/sensor_smoke/driver.ts
@@ -24,6 +24,20 @@ module.exports = class TuyaOAuth2DriverSensorSmoke extends TuyaOAuth2DriverSenso
       props.capabilities.push('alarm_smoke');
     }
 
+    if (!specifications) {
+      return props;
+    }
+
+    for (const specification of specifications.status) {
+      const tuyaCapability = specification.code;
+      const values = JSON.parse(specification.values);
+      if (tuyaCapability === 'alarm_smoke') {
+        if (!values.range.includes('normal')) {
+          props.settings['use_alarm_timeout'] = true;
+        }
+      }
+    }
+
     return props;
   }
 };

--- a/lib/TuyaOAuth2Client.ts
+++ b/lib/TuyaOAuth2Client.ts
@@ -337,10 +337,10 @@ export default class TuyaOAuth2Client extends OAuth2Client<TuyaOAuth2Token> {
 
   onUpdateWebhook(): void {
     if (this.__updateWebhookTimeout) {
-      clearTimeout(this.__updateWebhookTimeout);
+      this.homey.clearTimeout(this.__updateWebhookTimeout);
     }
 
-    this.__updateWebhookTimeout = setTimeout(() => {
+    this.__updateWebhookTimeout = this.homey.setTimeout(() => {
       Promise.resolve()
         .then(async () => {
           const keys = Array.from(this.registeredDevices.keys());

--- a/lib/TuyaOAuth2Device.ts
+++ b/lib/TuyaOAuth2Device.ts
@@ -154,7 +154,7 @@ export default class TuyaOAuth2Device extends OAuth2Device<TuyaOAuth2Client> {
   async onTuyaStatus(status: TuyaStatus, _changedStatusCodes: string[]): Promise<void> {
     // Wait at least 100ms for initialization before trying to pass the barrier again
     while (this.initBarrier) {
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise(resolve => this.homey.setTimeout(resolve, 100));
     }
 
     this.log('onTuyaStatus', JSON.stringify(status));

--- a/lib/TuyaOAuth2DeviceSensor.ts
+++ b/lib/TuyaOAuth2DeviceSensor.ts
@@ -3,6 +3,12 @@ import * as TuyaSensorMigrations from '../lib/migrations/TuyaSensorMigrations';
 import TuyaTimeOutAlarmDevice from './TuyaTimeOutAlarmDevice';
 
 export default class TuyaOAuth2DeviceSensor extends TuyaTimeOutAlarmDevice {
+  async onOAuth2Init(): Promise<void> {
+    await this.initAlarm('alarm_tamper', false).catch(this.error);
+
+    return super.onOAuth2Init();
+  }
+
   async performMigrations(): Promise<void> {
     await super.performMigrations();
     await TuyaSensorMigrations.performMigrations(this);

--- a/lib/TuyaOAuth2DeviceSensor.ts
+++ b/lib/TuyaOAuth2DeviceSensor.ts
@@ -1,8 +1,8 @@
 import { TuyaStatus } from '../types/TuyaTypes';
-import TuyaOAuth2Device from './TuyaOAuth2Device';
 import * as TuyaSensorMigrations from '../lib/migrations/TuyaSensorMigrations';
+import TuyaTimeOutAlarmDevice from './TuyaTimeOutAlarmDevice';
 
-export default class TuyaOAuth2DeviceSensor extends TuyaOAuth2Device {
+export default class TuyaOAuth2DeviceSensor extends TuyaTimeOutAlarmDevice {
   async performMigrations(): Promise<void> {
     await super.performMigrations();
     await TuyaSensorMigrations.performMigrations(this);
@@ -24,6 +24,23 @@ export default class TuyaOAuth2DeviceSensor extends TuyaOAuth2Device {
     // alarm_tamper
     if (typeof status['temper_alarm'] === 'boolean') {
       await this.safeSetCapabilityValue('alarm_tamper', status['temper_alarm']);
+    }
+  }
+
+  async setAlarmCapabilityValue(capability: string, value: boolean): Promise<void> {
+    if (this.getSetting('use_alarm_timeout')) {
+      if (value) {
+        await this.setAlarm(
+          capability,
+          () => this.setCapabilityValue(capability, true).catch(this.error),
+          () => this.setCapabilityValue(capability, false).catch(this.error),
+        );
+      } else {
+        // If the device does send false before the timeout ends we cut it short
+        await this.resetAlarm(capability, () => this.setCapabilityValue(capability, false).catch(this.error));
+      }
+    } else {
+      await this.setCapabilityValue(capability, value);
     }
   }
 }

--- a/lib/TuyaTimeOutAlarmDevice.ts
+++ b/lib/TuyaTimeOutAlarmDevice.ts
@@ -3,7 +3,11 @@ import TuyaOAuth2Device from './TuyaOAuth2Device';
 export default class TuyaTimeOutAlarmDevice extends TuyaOAuth2Device {
   alarmTimeouts: Record<string, NodeJS.Timeout | undefined> = {};
 
-  async initAlarm(capability: string): Promise<void> {
+  async initAlarm(capability: string, checkResetSetting = true): Promise<void> {
+    if (!this.hasCapability(capability)) {
+      return;
+    }
+
     const capabilityValue = this.getCapabilityValue(capability);
     if (typeof capabilityValue !== 'boolean') {
       // No value set, so reset it to false
@@ -15,7 +19,7 @@ export default class TuyaTimeOutAlarmDevice extends TuyaOAuth2Device {
       return;
     }
 
-    if (!this.getSetting('use_alarm_timeout')) {
+    if (!checkResetSetting || !this.getSetting('use_alarm_timeout')) {
       return;
     }
 

--- a/lib/TuyaTimeOutAlarmDevice.ts
+++ b/lib/TuyaTimeOutAlarmDevice.ts
@@ -1,0 +1,30 @@
+import TuyaOAuth2Device from './TuyaOAuth2Device';
+
+export default class TuyaTimeOutAlarmDevice extends TuyaOAuth2Device {
+  alarmTimeouts: Record<string, NodeJS.Timeout | undefined> = {};
+
+  async setAlarm(
+    capability: string,
+    onAlarmStarted: () => Promise<void>,
+    onAlarmEnded: () => Promise<void>,
+  ): Promise<void> {
+    if (this.alarmTimeouts[capability] !== undefined) {
+      // Extend the existing timeout if already running
+      clearTimeout(this.alarmTimeouts[capability]);
+    } else {
+      // Trigger if not
+      await onAlarmStarted();
+    }
+    // Disable the alarm after a set time, since we only get an "on" event
+    const alarmTimeout = Math.round((this.getSetting('alarm_timeout') ?? 10) * 1000);
+    this.alarmTimeouts[capability] = setTimeout(() => this.resetAlarm(capability, onAlarmEnded), alarmTimeout);
+  }
+
+  async resetAlarm(capability: string, onAlarmEnded: () => Promise<void>): Promise<void> {
+    // Clear the timeout for the next event
+    const currentTimeout = this.alarmTimeouts[capability];
+    clearTimeout(currentTimeout);
+    this.alarmTimeouts[capability] = undefined;
+    await onAlarmEnded();
+  }
+}

--- a/lib/TuyaTimeOutAlarmDevice.ts
+++ b/lib/TuyaTimeOutAlarmDevice.ts
@@ -10,21 +10,24 @@ export default class TuyaTimeOutAlarmDevice extends TuyaOAuth2Device {
   ): Promise<void> {
     if (this.alarmTimeouts[capability] !== undefined) {
       // Extend the existing timeout if already running
-      clearTimeout(this.alarmTimeouts[capability]);
+      this.homey.clearTimeout(this.alarmTimeouts[capability]);
     } else {
       // Trigger if not
       await onAlarmStarted();
     }
     // Disable the alarm after a set time, since we only get an "on" event
     const alarmTimeout = Math.round((this.getSetting('alarm_timeout') ?? 10) * 1000);
-    this.alarmTimeouts[capability] = setTimeout(() => this.resetAlarm(capability, onAlarmEnded), alarmTimeout);
+    this.alarmTimeouts[capability] = this.homey.setTimeout(
+      () => this.resetAlarm(capability, onAlarmEnded),
+      alarmTimeout,
+    );
   }
 
   async resetAlarm(capability: string, onAlarmEnded: () => Promise<void>): Promise<void> {
     // Clear the timeout for the next event
     const currentTimeout = this.alarmTimeouts[capability];
-    clearTimeout(currentTimeout);
-    this.alarmTimeouts[capability] = undefined;
+    this.homey.clearTimeout(currentTimeout);
+    delete this.alarmTimeouts[capability];
     await onAlarmEnded();
   }
 }

--- a/lib/TuyaTimeOutAlarmDevice.ts
+++ b/lib/TuyaTimeOutAlarmDevice.ts
@@ -3,6 +3,26 @@ import TuyaOAuth2Device from './TuyaOAuth2Device';
 export default class TuyaTimeOutAlarmDevice extends TuyaOAuth2Device {
   alarmTimeouts: Record<string, NodeJS.Timeout | undefined> = {};
 
+  async initAlarm(capability: string): Promise<void> {
+    const capabilityValue = this.getCapabilityValue(capability);
+    if (typeof capabilityValue !== 'boolean') {
+      // No value set, so reset it to false
+      await this.setCapabilityValue(capability, false).catch(this.error);
+      return;
+    }
+
+    if (!capabilityValue) {
+      return;
+    }
+
+    if (!this.getSetting('use_alarm_timeout')) {
+      return;
+    }
+
+    // Still active, reset now because timeout is no longer running
+    await this.setCapabilityValue(capability, false).catch(this.error);
+  }
+
   async setAlarm(
     capability: string,
     onAlarmStarted: () => Promise<void>,


### PR DESCRIPTION
**- Fixed sensor reset**
Some sensors never send an end signal, leaving the alarm perpetually triggered.
A setting has been added to allow timeouts to end sensor alarms without an end signal.
This setting is automatically set when adding motion or smoke sensors based on their specification.
Since contact sensors use a boolean it is not possible to do this.