### PR TITLE
Add data points to send_command flows

### DIFF
--- a/.homeycompose/flow/triggers/receive_status_boolean.json
+++ b/.homeycompose/flow/triggers/receive_status_boolean.json
@@ -6,7 +6,7 @@
     "en": "Status [[code]] gets a new Boolean value"
   },
   "hint": {
-    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs. Data points available outside of this specification may not actually be reported by the device."
   },
   "args": [
     {

--- a/.homeycompose/flow/triggers/receive_status_json.json
+++ b/.homeycompose/flow/triggers/receive_status_json.json
@@ -6,7 +6,7 @@
     "en": "Status [[code]] gets a new JSON value"
   },
   "hint": {
-    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs. Data points available outside of this specification may not actually be reported by the device."
   },
   "args": [
     {

--- a/.homeycompose/flow/triggers/receive_status_number.json
+++ b/.homeycompose/flow/triggers/receive_status_number.json
@@ -6,7 +6,7 @@
     "en": "Status [[code]] gets a new Number value"
   },
   "hint": {
-    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs. Data points available outside of this specification may not actually be reported by the device."
   },
   "args": [
     {

--- a/.homeycompose/flow/triggers/receive_status_string.json
+++ b/.homeycompose/flow/triggers/receive_status_string.json
@@ -6,7 +6,7 @@
     "en": "Status [[code]] gets a new String value"
   },
   "hint": {
-    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+    "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs. Data points available outside of this specification may not actually be reported by the device."
   },
   "args": [
     {

--- a/app.json
+++ b/app.json
@@ -392,7 +392,7 @@
           "en": "Status [[code]] gets a new Boolean value"
         },
         "hint": {
-          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs. Data points available outside of this specification may not actually be reported by the device."
         },
         "args": [
           {
@@ -433,7 +433,7 @@
           "en": "Status [[code]] gets a new JSON value"
         },
         "hint": {
-          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs. Data points available outside of this specification may not actually be reported by the device."
         },
         "args": [
           {
@@ -474,7 +474,7 @@
           "en": "Status [[code]] gets a new Number value"
         },
         "hint": {
-          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs. Data points available outside of this specification may not actually be reported by the device."
         },
         "args": [
           {
@@ -515,7 +515,7 @@
           "en": "Status [[code]] gets a new String value"
         },
         "hint": {
-          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs."
+          "en": "This is an advanced Flow card, that can be used to receive any status from a Tuya device. You can find the status codes in the Tuya API documentation at https://homey.link/tuya-docs. Data points available outside of this specification may not actually be reported by the device."
         },
         "args": [
           {

--- a/lib/TuyaOAuth2Client.ts
+++ b/lib/TuyaOAuth2Client.ts
@@ -226,7 +226,18 @@ export default class TuyaOAuth2Client extends OAuth2Client<TuyaOAuth2Token> {
   }
 
   async queryDataPoints(deviceId: string): Promise<TuyaDeviceDataPointResponse> {
+    // https://developer.tuya.com/en/docs/cloud/116cc8bf6f?id=Kcp2kwfrpe719
     return this._get(`/v2.0/cloud/thing/${deviceId}/shadow/properties`);
+  }
+
+  async setDataPoint(deviceId: string, dataPointId: string, value: unknown): Promise<void> {
+    // https://developer.tuya.com/en/docs/cloud/c057ad5cfd?id=Kcp2kxdzftp91
+    const payload = {
+      properties: JSON.stringify({
+        [dataPointId]: value,
+      }),
+    };
+    return this._post(`/v2.0/cloud/thing/${deviceId}/shadow/properties/issue`, payload);
   }
 
   async getWebRTCConfiguration({ deviceId }: { deviceId: string }): Promise<TuyaWebRTC> {

--- a/lib/TuyaOAuth2Device.ts
+++ b/lib/TuyaOAuth2Device.ts
@@ -1,5 +1,5 @@
 import { OAuth2Device } from 'homey-oauth2app';
-import { TuyaCommand, TuyaStatusResponse, TuyaWebRTC } from '../types/TuyaApiTypes';
+import { TuyaCommand, TuyaDeviceDataPointResponse, TuyaStatusResponse, TuyaWebRTC } from '../types/TuyaApiTypes';
 
 import { TuyaStatus, TuyaStatusUpdate } from '../types/TuyaTypes';
 import TuyaOAuth2Client from './TuyaOAuth2Client';
@@ -210,6 +210,16 @@ export default class TuyaOAuth2Device extends OAuth2Device<TuyaOAuth2Client> {
     return this.oAuth2Client.getDeviceStatus({
       deviceId,
     });
+  }
+
+  async queryDataPoints(): Promise<TuyaDeviceDataPointResponse> {
+    const { deviceId } = this.data;
+    return this.oAuth2Client.queryDataPoints(deviceId);
+  }
+
+  setDataPoint(dataPointId: string, value: unknown): Promise<void> {
+    const { deviceId } = this.data;
+    return this.oAuth2Client.setDataPoint(deviceId, dataPointId, value);
   }
 
   async getWebRTC(): Promise<TuyaWebRTC> {


### PR DESCRIPTION
**- Added data points to send_command and receive_status flows**
Since not all devices map their data points to the standard instruction/status set some functionality was unavailable for control.
Data points are now also retrieved and added to the options of send_command and receive_status flows if they are not available from the status yet. Since it is not guaranteed that the device will actually report these data points a warning was added to the receive_status hint.