### PR TITLE
Add support for third dimmer channel

### DIFF
--- a/app.json
+++ b/app.json
@@ -679,6 +679,32 @@
         ]
       },
       {
+        "id": "dimmer_sub_switch_3_turned_off",
+        "title": {
+          "en": "Turned channel 3 off"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=dimmer&capabilities=onoff.3"
+          }
+        ]
+      },
+      {
+        "id": "dimmer_sub_switch_3_turned_on",
+        "title": {
+          "en": "Turned channel 3 on"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=dimmer&capabilities=onoff.3"
+          }
+        ]
+      },
+      {
         "id": "dimmer_channel_1_dim_changed",
         "title": {
           "en": "Channel 1 dim-level changed"
@@ -721,6 +747,29 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=dimmer&capabilities=dim.2"
+          }
+        ]
+      },
+      {
+        "id": "dimmer_channel_3_dim_changed",
+        "title": {
+          "en": "Channel 3 dim-level changed"
+        },
+        "tokens": [
+          {
+            "name": "value",
+            "type": "number",
+            "title": {
+              "en": "Level"
+            },
+            "example": 0.5
+          }
+        ],
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=dimmer&capabilities=dim.3"
           }
         ]
       },
@@ -1282,6 +1331,32 @@
         ]
       },
       {
+        "id": "dimmer_sub_switch_3_off",
+        "title": {
+          "en": "Turn channel 3 off"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=dimmer&capabilities=onoff.3"
+          }
+        ]
+      },
+      {
+        "id": "dimmer_sub_switch_3_on",
+        "title": {
+          "en": "Turn channel 3 on"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=dimmer&capabilities=onoff.3"
+          }
+        ]
+      },
+      {
         "id": "dimmer_channel_1_dim",
         "highlight": true,
         "title": {
@@ -1326,6 +1401,37 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=dimmer&capabilities=dim.2"
+          },
+          {
+            "name": "value",
+            "title": {
+              "en": "Level"
+            },
+            "type": "range",
+            "min": 0,
+            "max": 1,
+            "step": 0.1,
+            "value": 0.5,
+            "label": "%",
+            "labelMultiplier": 100,
+            "labelDecimals": 0
+          }
+        ]
+      },
+      {
+        "id": "dimmer_channel_3_dim",
+        "highlight": true,
+        "title": {
+          "en": "Dim channel 3"
+        },
+        "titleFormatted": {
+          "en": "Dim channel 3 to [[value]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=dimmer&capabilities=dim.3"
           },
           {
             "name": "value",
@@ -1654,6 +1760,19 @@
             "type": "device",
             "name": "device",
             "filter": "driver_id=dimmer&capabilities=onoff.2"
+          }
+        ]
+      },
+      {
+        "id": "dimmer_sub_switch_3_is_on",
+        "title": {
+          "en": "Channel 3 is turned !{{on|off}}"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=dimmer&capabilities=onoff.3"
           }
         ]
       },
@@ -2127,6 +2246,58 @@
               "type": "dropdown",
               "label": {
                 "en": "Lamp Type 2"
+              },
+              "value": "led",
+              "values": [
+                {
+                  "id": "led",
+                  "label": {
+                    "en": "LED"
+                  }
+                },
+                {
+                  "id": "incandescent",
+                  "label": {
+                    "en": "Incandescent"
+                  }
+                },
+                {
+                  "id": "halogen",
+                  "label": {
+                    "en": "Halogen"
+                  }
+                }
+              ]
+            },
+            {
+              "id": "brightness_min_3",
+              "type": "number",
+              "label": {
+                "en": "Minimum Brightness 3"
+              },
+              "value": 0,
+              "min": 0,
+              "max": 100,
+              "step": 0.1,
+              "units": "%"
+            },
+            {
+              "id": "brightness_max_3",
+              "type": "number",
+              "label": {
+                "en": "Maximum Brightness 3"
+              },
+              "value": 100,
+              "min": 1,
+              "max": 100,
+              "step": 0.1,
+              "units": "%"
+            },
+            {
+              "id": "led_type_3",
+              "type": "dropdown",
+              "label": {
+                "en": "Lamp Type 3"
               },
               "value": "led",
               "values": [

--- a/drivers/dimmer/TuyaDimmerConstants.ts
+++ b/drivers/dimmer/TuyaDimmerConstants.ts
@@ -5,12 +5,25 @@ export const DIMMER_SETTING_LABELS = {
   brightness_max_1: 'Maximum Brightness 1',
   brightness_min_2: 'Minimum Brightness 2',
   brightness_max_2: 'Maximum Brightness 2',
+  brightness_min_3: 'Minimum Brightness 3',
+  brightness_max_3: 'Maximum Brightness 3',
   led_type_1: 'Lamp Type 1',
   led_type_2: 'Lamp Type 2',
+  led_type_3: 'Lamp Type 3',
 } as const;
 
 export const SIMPLE_DIMMER_CAPABILITIES = {
-  read_write: ['switch_led_1', 'bright_value_1', 'switch_led_2', 'bright_value_2'],
+  read_write: ['switch_led_1', 'bright_value_1', 'switch_led_2', 'bright_value_2', 'switch_led_3', 'bright_value_3'],
   read_only: [],
-  setting: ['brightness_min_1', 'brightness_max_1', 'brightness_min_2', 'brightness_max_2', 'led_type_1', 'led_type_2'],
+  setting: [
+    'brightness_min_1',
+    'brightness_max_1',
+    'brightness_min_2',
+    'brightness_max_2',
+    'brightness_min_3',
+    'brightness_max_3',
+    'led_type_1',
+    'led_type_2',
+    'led_type_3',
+  ],
 } as const;

--- a/drivers/dimmer/device.ts
+++ b/drivers/dimmer/device.ts
@@ -16,7 +16,7 @@ export default class TuyaOAuth2DeviceDimmer extends TuyaOAuth2Device {
       this.registerCapabilityListener('dim', value => this.allDim(value));
     }
 
-    for (let switch_i = 1; switch_i <= 2; switch_i++) {
+    for (let switch_i = 1; switch_i <= 3; switch_i++) {
       if (this.hasCapability(`onoff.${switch_i}`)) {
         this.registerCapabilityListener(`onoff.${switch_i}`, value =>
           this.singleOnOff(value, `switch_led_${switch_i}`),
@@ -40,7 +40,7 @@ export default class TuyaOAuth2DeviceDimmer extends TuyaOAuth2Device {
 
     let anySwitchOn = false;
 
-    for (let switch_i = 1; switch_i <= 2; switch_i++) {
+    for (let switch_i = 1; switch_i <= 3; switch_i++) {
       const tuyaSwitchCapability = `switch_led_${switch_i}`;
       const tuyaBrightnessCapability = `bright_value_${switch_i}`;
       const tuyaBrightnessMin = `brightness_min_${switch_i}`;

--- a/drivers/dimmer/driver.flow.compose.json
+++ b/drivers/dimmer/driver.flow.compose.json
@@ -29,6 +29,20 @@
       }
     },
     {
+      "id": "dimmer_sub_switch_3_off",
+      "$filter": "capabilities=onoff.3",
+      "title": {
+        "en": "Turn channel 3 off"
+      }
+    },
+    {
+      "id": "dimmer_sub_switch_3_on",
+      "$filter": "capabilities=onoff.3",
+      "title": {
+        "en": "Turn channel 3 on"
+      }
+    },
+    {
       "id": "dimmer_channel_1_dim",
       "$filter": "capabilities=dim.1",
       "highlight": true,
@@ -81,6 +95,33 @@
           "labelDecimals": 0
         }
       ]
+    },
+    {
+      "id": "dimmer_channel_3_dim",
+      "$filter": "capabilities=dim.3",
+      "highlight": true,
+      "title": {
+        "en": "Dim channel 3"
+      },
+      "titleFormatted": {
+        "en": "Dim channel 3 to [[value]]"
+      },
+      "args": [
+        {
+          "name": "value",
+          "title": {
+            "en": "Level"
+          },
+          "type": "range",
+          "min": 0,
+          "max": 1,
+          "step": 0.1,
+          "value": 0.5,
+          "label": "%",
+          "labelMultiplier": 100,
+          "labelDecimals": 0
+        }
+      ]
     }
   ],
   "conditions": [
@@ -96,6 +137,13 @@
       "$filter": "capabilities=onoff.2",
       "title": {
         "en": "Channel 2 is turned !{{on|off}}"
+      }
+    },
+    {
+      "id": "dimmer_sub_switch_3_is_on",
+      "$filter": "capabilities=onoff.3",
+      "title": {
+        "en": "Channel 3 is turned !{{on|off}}"
       }
     }
   ],
@@ -129,6 +177,20 @@
       }
     },
     {
+      "id": "dimmer_sub_switch_3_turned_off",
+      "$filter": "capabilities=onoff.3",
+      "title": {
+        "en": "Turned channel 3 off"
+      }
+    },
+    {
+      "id": "dimmer_sub_switch_3_turned_on",
+      "$filter": "capabilities=onoff.3",
+      "title": {
+        "en": "Turned channel 3 on"
+      }
+    },
+    {
       "id": "dimmer_channel_1_dim_changed",
       "$filter": "capabilities=dim.1",
       "title": {
@@ -150,6 +212,23 @@
       "$filter": "capabilities=dim.2",
       "title": {
         "en": "Channel 2 dim-level changed"
+      },
+      "tokens": [
+        {
+          "name": "value",
+          "type": "number",
+          "title": {
+            "en": "Level"
+          },
+          "example": 0.5
+        }
+      ]
+    },
+    {
+      "id": "dimmer_channel_3_dim_changed",
+      "$filter": "capabilities=dim.3",
+      "title": {
+        "en": "Channel 3 dim-level changed"
       },
       "tokens": [
         {

--- a/drivers/dimmer/driver.settings.compose.json
+++ b/drivers/dimmer/driver.settings.compose.json
@@ -108,6 +108,58 @@
             }
           }
         ]
+      },
+      {
+        "id": "brightness_min_3",
+        "type": "number",
+        "label": {
+          "en": "Minimum Brightness 3"
+        },
+        "value": 0,
+        "min": 0,
+        "max": 100,
+        "step": 0.1,
+        "units": "%"
+      },
+      {
+        "id": "brightness_max_3",
+        "type": "number",
+        "label": {
+          "en": "Maximum Brightness 3"
+        },
+        "value": 100,
+        "min": 1,
+        "max": 100,
+        "step": 0.1,
+        "units": "%"
+      },
+      {
+        "id": "led_type_3",
+        "type": "dropdown",
+        "label": {
+          "en": "Lamp Type 3"
+        },
+        "value": "led",
+        "values": [
+          {
+            "id": "led",
+            "label": {
+              "en": "LED"
+            }
+          },
+          {
+            "id": "incandescent",
+            "label": {
+              "en": "Incandescent"
+            }
+          },
+          {
+            "id": "halogen",
+            "label": {
+              "en": "Halogen"
+            }
+          }
+        ]
       }
     ]
   },

--- a/drivers/dimmer/driver.ts
+++ b/drivers/dimmer/driver.ts
@@ -22,7 +22,7 @@ module.exports = class TuyaOAuth2DriverDimmer extends TuyaOAuth2Driver {
   async onInit(): Promise<void> {
     await super.onInit();
 
-    for (let switch_i = 1; switch_i <= 2; switch_i++) {
+    for (let switch_i = 1; switch_i <= 3; switch_i++) {
       this.homey.flow
         .getConditionCard(`dimmer_sub_switch_${switch_i}_is_on`)
         .registerRunListener((args: DeviceArgs) => {
@@ -66,11 +66,15 @@ module.exports = class TuyaOAuth2DriverDimmer extends TuyaOAuth2Driver {
         props.store.tuya_capabilities.push(tuyaCapability);
       }
 
-      if (tuyaCapability === 'switch_led_1' || tuyaCapability === 'switch_led_2') {
+      if (tuyaCapability === 'switch_led_1' || tuyaCapability === 'switch_led_2' || tuyaCapability === 'switch_led_3') {
         props.store.tuya_switches.push(tuyaCapability);
       }
 
-      if (tuyaCapability === 'bright_value_1' || tuyaCapability === 'bright_value_2') {
+      if (
+        tuyaCapability === 'bright_value_1' ||
+        tuyaCapability === 'bright_value_2' ||
+        tuyaCapability === 'bright_value_3'
+      ) {
         props.store.tuya_dimmers.push(tuyaCapability);
       }
     }
@@ -80,8 +84,8 @@ module.exports = class TuyaOAuth2DriverDimmer extends TuyaOAuth2Driver {
       props.capabilities.push('onoff');
     }
 
-    if (props.store.tuya_switches.length === 2) {
-      for (let switch_i = 1; switch_i <= 2; switch_i++) {
+    if (props.store.tuya_switches.length > 1) {
+      for (let switch_i = 1; switch_i <= 3; switch_i++) {
         const subSwitchCapability = `onoff.${switch_i}`;
         props.capabilities.push(subSwitchCapability);
         props.capabilitiesOptions[subSwitchCapability] = {
@@ -110,8 +114,8 @@ module.exports = class TuyaOAuth2DriverDimmer extends TuyaOAuth2Driver {
       props.capabilities.push('dim');
     }
 
-    if (props.store.tuya_dimmers.length === 2) {
-      for (let switch_i = 1; switch_i <= 2; switch_i++) {
+    if (props.store.tuya_dimmers.length > 1) {
+      for (let switch_i = 1; switch_i <= 3; switch_i++) {
         const subSwitchCapability = `dim.${switch_i}`;
         props.capabilities.push(subSwitchCapability);
         props.capabilitiesOptions[subSwitchCapability] = {
@@ -139,6 +143,11 @@ module.exports = class TuyaOAuth2DriverDimmer extends TuyaOAuth2Driver {
       if (tuyaCapability === 'bright_value_2') {
         props.settings['brightness_min_2'] = values.min / TUYA_PERCENTAGE_SCALING;
         props.settings['brightness_max_2'] = values.max / TUYA_PERCENTAGE_SCALING;
+      }
+
+      if (tuyaCapability === 'bright_value_3') {
+        props.settings['brightness_min_3'] = values.min / TUYA_PERCENTAGE_SCALING;
+        props.settings['brightness_max_3'] = values.max / TUYA_PERCENTAGE_SCALING;
       }
     }
 


### PR DESCRIPTION
#163 added the `tgkg` category to our dimmer driver, but did not add support for the possible third channel. This PR add support for that third channel as described in https://developer.tuya.com/en/docs/iot/s?id=K9t2a5mn56bdr. 