### PR TITLE
1.3.0 Fixes

### DIFF
--- a/drivers/fan/driver.ts
+++ b/drivers/fan/driver.ts
@@ -121,7 +121,7 @@ module.exports = class TuyaOAuth2DriverFan extends TuyaOAuth2DriverWithLight {
 
     for (const statusSpecification of specifications.status) {
       const tuyaCapability = statusSpecification.code;
-      const values = JSON.parse(statusSpecification.values);
+      const values: Record<string, unknown> = JSON.parse(statusSpecification.values);
 
       // Fan
       if (tuyaCapability === 'fan_speed_percent') {
@@ -132,9 +132,11 @@ module.exports = class TuyaOAuth2DriverFan extends TuyaOAuth2DriverWithLight {
         };
       }
 
-      if (tuyaCapability === 'fan_speed') {
+      const speeds = (values.range as never[] | undefined)?.length;
+
+      if (tuyaCapability === 'fan_speed' && speeds) {
         const legacyFanSpeedsEnum = [];
-        for (let i = values.range.length; i >= 1; i--) {
+        for (let i = speeds; i >= 1; i--) {
           legacyFanSpeedsEnum.push({
             id: `${i}`,
             title: `${i}`,

--- a/drivers/light/driver.ts
+++ b/drivers/light/driver.ts
@@ -94,6 +94,8 @@ module.exports = class TuyaOAuth2DriverLight extends TuyaOAuth2DriverWithLight {
     const props = super.onTuyaPairListDeviceProperties(device, specifications, dataPoints);
     props.store.tuya_switches = [];
 
+    props.store._migrations = [...(props.store._migrations ?? []), 'light_fix_undefined_specifications'];
+
     // Add this before the sub-capabilities, so it becomes the quick toggle
     props.capabilities.push('onoff');
 

--- a/drivers/light/driver.ts
+++ b/drivers/light/driver.ts
@@ -94,7 +94,12 @@ module.exports = class TuyaOAuth2DriverLight extends TuyaOAuth2DriverWithLight {
     const props = super.onTuyaPairListDeviceProperties(device, specifications, dataPoints);
     props.store.tuya_switches = [];
 
-    props.store._migrations = [...(props.store._migrations ?? []), 'light_fix_undefined_specifications'];
+    props.store._migrations = [
+      ...(props.store._migrations ?? []),
+      'light_fix_undefined_specifications',
+      'light_switch_capability',
+      'light_switch_on_dim',
+    ];
 
     // Add this before the sub-capabilities, so it becomes the quick toggle
     props.capabilities.push('onoff');

--- a/lib/migrations/TuyaLightMigrations.ts
+++ b/lib/migrations/TuyaLightMigrations.ts
@@ -1,8 +1,10 @@
 import type TuyaOAuth2DeviceLight from '../../drivers/light/device';
+import { executeMigration } from './MigrationStore';
 
 export async function performMigrations(device: TuyaOAuth2DeviceLight): Promise<void> {
   await switchCapabilityMigration(device).catch(device.error);
   await otherSwitchOnDimMigration(device).catch(device.error);
+  await fixUndefinedSpecifications(device).catch(device.error);
 }
 
 async function switchCapabilityMigration(device: TuyaOAuth2DeviceLight): Promise<void> {
@@ -105,4 +107,74 @@ async function otherSwitchOnDimMigration(device: TuyaOAuth2DeviceLight): Promise
 
     device.log('Switch all setOnDim migration complete');
   }
+}
+
+async function fixUndefinedSpecifications(device: TuyaOAuth2DeviceLight): Promise<void> {
+  await executeMigration(device, 'light_fix_undefined_specifications', async () => {
+    device.log('Ensuring light specifications are not undefined...');
+    const specifications = await device.oAuth2Client.getSpecification(device.data.deviceId);
+    const category = device.getStoreValue('tuya_category');
+
+    // Set fallback values to the defaults
+    if (category === 'dj') {
+      await device.setStoreValue('tuya_brightness', { min: 25, max: 255, scale: 0, step: 1 });
+      await device.setStoreValue('tuya_temperature', { min: 0, max: 255, scale: 0, step: 1 });
+      await device.setStoreValue('tuya_colour', {
+        h: { min: 0, max: 360, scale: 0, step: 1 },
+        s: { min: 0, max: 255, scale: 0, step: 1 },
+        v: { min: 0, max: 255, scale: 0, step: 1 },
+      });
+      await device.setStoreValue('tuya_brightness_v2', { min: 10, max: 1000, scale: 0, step: 1 });
+      await device.setStoreValue('tuya_temperature_v2', { min: 0, max: 1000, scale: 0, step: 1 });
+      await device.setStoreValue('tuya_colour_v2', {
+        h: { min: 0, max: 360, scale: 0, step: 1 },
+        s: { min: 0, max: 1000, scale: 0, step: 1 },
+        v: { min: 0, max: 1000, scale: 0, step: 1 },
+      });
+    } else {
+      await device.setStoreValue('tuya_brightness', { min: 10, max: 1000, scale: 0, step: 1 });
+      await device.setStoreValue('tuya_temperature', { min: 0, max: 1000, scale: 0, step: 1 });
+      await device.setStoreValue('tuya_colour', {
+        h: { min: 0, max: 360, scale: 0, step: 1 },
+        s: { min: 0, max: 1000, scale: 0, step: 1 },
+        v: { min: 0, max: 1000, scale: 0, step: 1 },
+      });
+    }
+
+    if (!specifications || !specifications.functions) {
+      device.log('Defining light specifications completed with defaults');
+      return;
+    }
+
+    // Set device-specified values
+    for (const functionSpecification of specifications.functions) {
+      const tuyaCapability = functionSpecification.code;
+      const values = JSON.parse(functionSpecification.values);
+
+      if (tuyaCapability === 'bright_value') {
+        await device.setStoreValue('tuya_brightness', { ...device.store.tuya_brightness, ...values });
+      } else if (tuyaCapability === 'bright_value_v2') {
+        await device.setStoreValue('tuya_brightness_v2', { ...device.store.tuya_brightness_v2, ...values });
+      } else if (tuyaCapability === 'temp_value') {
+        await device.setStoreValue('tuya_temperature', { ...device.store.tuya_temperature, ...values });
+      } else if (tuyaCapability === 'temp_value_v2') {
+        await device.setStoreValue('tuya_temperature_v2', { ...device.store.tuya_temperature_v2, ...values });
+      } else if (tuyaCapability === 'colour_data') {
+        const colour_data = {
+          h: { ...device.store.tuya_colour.h, ...values?.h },
+          s: { ...device.store.tuya_colour.s, ...values?.s },
+          v: { ...device.store.tuya_colour.v, ...values?.v },
+        };
+        await device.setStoreValue('tuya_colour', colour_data);
+      } else if (tuyaCapability === 'colour_data_v2') {
+        const colour_data = {
+          h: { ...device.store.tuya_colour_v2.h, ...values?.h },
+          s: { ...device.store.tuya_colour_v2.s, ...values?.s },
+          v: { ...device.store.tuya_colour_v2.v, ...values?.v },
+        };
+        await device.setStoreValue('tuya_colour_v2', colour_data);
+      }
+    }
+    device.log('Defining light specifications completed');
+  });
 }

--- a/lib/migrations/TuyaLightMigrations.ts
+++ b/lib/migrations/TuyaLightMigrations.ts
@@ -8,105 +8,109 @@ export async function performMigrations(device: TuyaOAuth2DeviceLight): Promise<
 }
 
 async function switchCapabilityMigration(device: TuyaOAuth2DeviceLight): Promise<void> {
-  // switch capabilities migration
-  const tuyaSwitches = device.getStore().tuya_switches;
+  await executeMigration(device, 'light_switch_capability', async () => {
+    // switch capabilities migration
+    const tuyaSwitches = device.getStore().tuya_switches;
 
-  if (tuyaSwitches === undefined) {
-    device.log('Migrating switch capabilities...');
-    const deviceStatus = await device.getStatus();
+    if (tuyaSwitches === undefined) {
+      device.log('Migrating switch capabilities...');
+      const deviceStatus = await device.getStatus();
 
-    let hasSwitchLed = false;
-    let hasSwitch = false;
+      let hasSwitchLed = false;
+      let hasSwitch = false;
 
-    const store = device.getStore();
-    const tuyaCapabilities = store.tuya_capabilities;
-    const tuyaSwitches = store.tuya_switches ?? [];
+      const store = device.getStore();
+      const tuyaCapabilities = store.tuya_capabilities;
+      const tuyaSwitches = store.tuya_switches ?? [];
 
-    for (const status of deviceStatus) {
-      const tuyaCapability = status.code;
-      hasSwitchLed = hasSwitchLed || tuyaCapability === 'switch_led';
-      hasSwitch = hasSwitch || tuyaCapability === 'switch';
+      for (const status of deviceStatus) {
+        const tuyaCapability = status.code;
+        hasSwitchLed = hasSwitchLed || tuyaCapability === 'switch_led';
+        hasSwitch = hasSwitch || tuyaCapability === 'switch';
 
-      if (tuyaCapability === 'switch_led' || tuyaCapability === 'switch') {
-        if (!tuyaCapabilities.includes(tuyaCapability)) {
-          tuyaCapabilities.push(tuyaCapability);
+        if (tuyaCapability === 'switch_led' || tuyaCapability === 'switch') {
+          if (!tuyaCapabilities.includes(tuyaCapability)) {
+            tuyaCapabilities.push(tuyaCapability);
+          }
+          tuyaSwitches.push(tuyaCapability);
         }
-        tuyaSwitches.push(tuyaCapability);
       }
-    }
 
-    await device.setStoreValue('tuya_capabilities', tuyaCapabilities);
-    await device.setStoreValue('tuya_switches', tuyaSwitches);
+      await device.setStoreValue('tuya_capabilities', tuyaCapabilities);
+      await device.setStoreValue('tuya_switches', tuyaSwitches);
 
-    if (hasSwitch) {
-      // Capability migration needs to happen
-      if (hasSwitchLed) {
-        // Add sub-capabilities
-        await device.addCapability('onoff.switch_led');
-        await device.addCapability('onoff.switch');
+      if (hasSwitch) {
+        // Capability migration needs to happen
+        if (hasSwitchLed) {
+          // Add sub-capabilities
+          await device.addCapability('onoff.switch_led');
+          await device.addCapability('onoff.switch');
 
-        await device.setCapabilityOptions('onoff.switch_led', {
-          title: {
-            en: `Light`,
-          },
-          insightsTitleTrue: {
-            en: `Turned on (Light)`,
-          },
-          insightsTitleFalse: {
-            en: `Turned off (Light)`,
-          },
-        });
-        await device.setCapabilityOptions('onoff.switch', {
-          title: {
-            en: `Other`,
-          },
-          insightsTitleTrue: {
-            en: `Turned on (Other)`,
-          },
-          insightsTitleFalse: {
-            en: `Turned off (Other)`,
-          },
-        });
-      } else {
-        // Add missing onoff
-        await device.addCapability('onoff');
+          await device.setCapabilityOptions('onoff.switch_led', {
+            title: {
+              en: `Light`,
+            },
+            insightsTitleTrue: {
+              en: `Turned on (Light)`,
+            },
+            insightsTitleFalse: {
+              en: `Turned off (Light)`,
+            },
+          });
+          await device.setCapabilityOptions('onoff.switch', {
+            title: {
+              en: `Other`,
+            },
+            insightsTitleTrue: {
+              en: `Turned on (Other)`,
+            },
+            insightsTitleFalse: {
+              en: `Turned off (Other)`,
+            },
+          });
+        } else {
+          // Add missing onoff
+          await device.addCapability('onoff');
 
-        await device.setCapabilityOptions('onoff', {
-          title: {
-            en: 'Switch All',
-          },
-          setOnDim: false,
-          preventInsights: true,
-        });
+          await device.setCapabilityOptions('onoff', {
+            title: {
+              en: 'Switch All',
+            },
+            setOnDim: false,
+            preventInsights: true,
+          });
+        }
       }
+      device.log('Switch capabilities migration complete');
     }
-    device.log('Switch capabilities migration complete');
-  }
+  });
 }
 
 async function otherSwitchOnDimMigration(device: TuyaOAuth2DeviceLight): Promise<void> {
-  // Add setOnDim: false to onoff for devices that have an additional switch
+  await executeMigration(device, 'light_switch_on_dim', async () => {
+    // Add setOnDim: false to onoff for devices that have an additional switch
 
-  // The Homey API throws an error if no capability options have been set before
-  let capabilityOptions;
-  try {
-    capabilityOptions = device.getCapabilityOptions('onoff');
-  } catch (err) {
-    capabilityOptions = {};
-  }
+    // The Homey API throws an error if no capability options have been set before
+    let capabilityOptions;
+    try {
+      capabilityOptions = device.getCapabilityOptions('onoff');
+    } catch (err) {
+      capabilityOptions = {};
+    }
 
-  const tuyaSwitches = device.getStore().tuya_switches;
+    const tuyaSwitches = device.getStore().tuya_switches;
 
-  if (tuyaSwitches.length > 1 && capabilityOptions?.setOnDim !== false) {
-    device.log('Migrating switch all setOnDim...');
+    if (tuyaSwitches.length > 1 && capabilityOptions?.setOnDim !== false) {
+      device.log('Migrating switch all setOnDim...');
 
-    await device.setCapabilityOptions('onoff', {
-      ...capabilityOptions,
-      setOnDim: false,
-    });
+      await device.setCapabilityOptions('onoff', {
+        ...capabilityOptions,
+        setOnDim: false,
+      });
 
-    device.log('Switch all setOnDim migration complete');
-  }
+      device.log('Switch all setOnDim migration complete');
+    }
+  });
 }
 
 async function fixUndefinedSpecifications(device: TuyaOAuth2DeviceLight): Promise<void> {


### PR DESCRIPTION
- **Fixed assumption that fan specifications are defined**
Some fan devices give malformed specifications, resulting in not being able to add fans.
In these cases the default specifications from the Tuya documentation are now assumed.

- **Added migration to fix undefined light specifications**
Some lights added in older versions may be missing some specifications, and never received them since.
A migration was added to ensure every existing light has these values set.