### PR TITLE
Change current capability value when changing scale factor

### DIFF
--- a/drivers/heater/device.ts
+++ b/drivers/heater/device.ts
@@ -1,5 +1,7 @@
 import TuyaOAuth2Device from '../../lib/TuyaOAuth2Device';
-import { TuyaStatus } from '../../types/TuyaTypes';
+import { SettingsEvent, TuyaStatus } from '../../types/TuyaTypes';
+import { HEATER_CAPABILITIES_MAPPING, HomeyHeaterSettings } from './TuyaHeaterConstants';
+import * as TuyaOAuth2Util from '../../lib/TuyaOAuth2Util';
 
 module.exports = class TuyaOAuth2DeviceHeater extends TuyaOAuth2Device {
   async onOAuth2Init(): Promise<void> {
@@ -117,6 +119,15 @@ module.exports = class TuyaOAuth2DeviceHeater extends TuyaOAuth2Device {
         code: 'mode_eco',
         value: value,
       });
+    }
+  }
+
+  async onSettings(event: SettingsEvent<HomeyHeaterSettings>): Promise<string | void> {
+    for (const tuyaCapability of ['temp_set', 'temp_current', 'work_power'] as const) {
+      const homeyCapability = HEATER_CAPABILITIES_MAPPING[tuyaCapability];
+      await TuyaOAuth2Util.handleScaleSetting(this, event, `${tuyaCapability}_scaling`, homeyCapability).catch(
+        this.error,
+      );
     }
   }
 };

--- a/drivers/sensor_climate/device.ts
+++ b/drivers/sensor_climate/device.ts
@@ -2,7 +2,6 @@ import {
   HomeyClimateSensorSettings,
   CLIMATE_CAPABILITY_MAPPING,
   CLIMATE_SENSOR_CAPABILITIES,
-  CLIMATE_SENSOR_SETTING_LABELS,
 } from './TuyaClimateSensorConstants';
 import TuyaOAuth2DeviceSensor from '../../lib/TuyaOAuth2DeviceSensor';
 import { constIncludes, getFromMap } from '../../lib/TuyaOAuth2Util';
@@ -53,6 +52,11 @@ module.exports = class TuyaOAuth2DeviceSensorClimate extends TuyaOAuth2DeviceSen
   }
 
   async onSettings(event: SettingsEvent<HomeyClimateSensorSettings>): Promise<string | void> {
-    return await TuyaOAuth2Util.onSettings(this, event, CLIMATE_SENSOR_SETTING_LABELS);
+    for (const tuyaCapability of ['va_temperature', 'va_humidity', 'bright_value'] as const) {
+      const homeyCapability = CLIMATE_CAPABILITY_MAPPING[tuyaCapability];
+      await TuyaOAuth2Util.handleScaleSetting(this, event, `${tuyaCapability}_scaling`, homeyCapability).catch(
+        this.error,
+      );
+    }
   }
 };

--- a/drivers/socket/device.ts
+++ b/drivers/socket/device.ts
@@ -139,6 +139,14 @@ export default class TuyaOAuth2DeviceSocket extends TuyaOAuth2Device {
   }
 
   async onSettings(event: SettingsEvent<HomeySocketSettings>): Promise<string | void> {
+    for (const [settingKey, homeyCapability] of [
+      ['power_scaling', 'measure_power'],
+      ['cur_current_scaling', 'measure_current'],
+      ['cur_voltage_scaling', 'measure_voltage'],
+    ] as const) {
+      await TuyaOAuth2Util.handleScaleSetting(this, event, settingKey, homeyCapability).catch(this.error);
+    }
+
     const tuyaSettingsEvent = TuyaOAuth2Util.filterTuyaSettings<HomeySocketSettings, TuyaSocketSettings>(event, [
       'child_lock',
       'relay_status',

--- a/lib/TuyaOAuth2Util.ts
+++ b/lib/TuyaOAuth2Util.ts
@@ -110,17 +110,19 @@ export function hasJsonStructure(str: unknown): boolean {
   }
 }
 
-/**
- * @returns {boolean} - Whether the scaling was successfully changed
- */
 export async function handleScaleSetting<T extends string, S extends Record<T, string>>(
   device: TuyaOAuth2Device,
   event: SettingsEvent<S>,
   settingKey: T,
   homeyCapability: string | undefined,
-): Promise<boolean> {
-  if (!event.changedKeys.includes(settingKey)) return true;
-  if (!homeyCapability || !device.hasCapability(homeyCapability)) return false;
+): Promise<void> {
+  if (!event.changedKeys.includes(settingKey)) {
+    return;
+  }
+
+  if (!homeyCapability || !device.hasCapability(homeyCapability)) {
+    return;
+  }
 
   const oldScaling = 10.0 ** Number.parseInt(event.oldSettings[settingKey] ?? '0', 10);
   const newScaling = 10.0 ** Number.parseInt(event.newSettings[settingKey] ?? '0', 10);
@@ -128,7 +130,6 @@ export async function handleScaleSetting<T extends string, S extends Record<T, s
   const newValue = (oldValue * oldScaling) / newScaling;
 
   await device.setCapabilityValue(homeyCapability, newValue);
-  return true;
 }
 
 /**


### PR DESCRIPTION
- **Change current capability value when changing scale factor**
When changing scaling factors in settings the capability value now immediately uses the new scale, instead of having to wait for a new value.

Fixes https://github.com/athombv/com.tuya/issues/196