### PR TITLE
Fix child lock flow filters

### DIFF
--- a/.homeycompose/flow/triggers/child_lock_false.json
+++ b/.homeycompose/flow/triggers/child_lock_false.json
@@ -7,7 +7,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "heater",
+        "driver_id": "fan|heater|socket",
         "capabilities": "child_lock"
       },
       "title": {

--- a/.homeycompose/flow/triggers/child_lock_true.json
+++ b/.homeycompose/flow/triggers/child_lock_true.json
@@ -7,7 +7,7 @@
       "name": "device",
       "type": "device",
       "filter": {
-        "driver_id": "heater",
+        "driver_id": "fan|heater|socket",
         "capabilities": "child_lock"
       },
       "title": {

--- a/app.json
+++ b/app.json
@@ -318,7 +318,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "heater",
+              "driver_id": "fan|heater|socket",
               "capabilities": "child_lock"
             },
             "title": {
@@ -337,7 +337,7 @@
             "name": "device",
             "type": "device",
             "filter": {
-              "driver_id": "heater",
+              "driver_id": "fan|heater|socket",
               "capabilities": "child_lock"
             },
             "title": {


### PR DESCRIPTION
- **Fixed child lock flow filters**
Some drivers that support the child lock capability were missing from the flows for that capability.
This is no fixed.