### PR TITLE
Handle webhook data deduplication in device implementation

### DIFF
--- a/types/TuyaTypes.ts
+++ b/types/TuyaTypes.ts
@@ -1,6 +1,7 @@
 import type TuyaOAuth2Device from '../lib/TuyaOAuth2Device';
 
 export type TuyaStatus = Record<string, unknown>;
+export type TuyaStatusSource = 'sync' | 'online' | 'offline' | 'status' | 'iot_core_status';
 
 // Legacy status update
 export type TuyaStatusUpdate<T> = {
@@ -21,7 +22,7 @@ export type TuyaIotCoreStatusUpdate<T> = {
 export type DeviceRegistration = {
   productId: string;
   deviceId: string;
-  onStatus: (status: TuyaStatus, changedStatusCodes: string[]) => Promise<void>;
+  onStatus: (source: TuyaStatusSource, status: TuyaStatus, changedStatusCodes: string[]) => Promise<void>;
 };
 
 export type SettingsEvent<T extends { [key: string]: unknown }> = {


### PR DESCRIPTION
No longer use the webhook data id to deduplicate data, as it seems that the data from the status webhook needs to take precedence.